### PR TITLE
Support literal types in playground/function explorer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "streamlit-extras"
-version = "0.1.2"
+version = "0.1.3"
 license = "Apache 2.0"
 description = "A library to discover, try, install and share Streamlit extras"
 authors = ["Arnaud Miribel <arnaudmiribel@gmail.com>"]

--- a/src/streamlit_extras/badges/__init__.py
+++ b/src/streamlit_extras/badges/__init__.py
@@ -1,10 +1,12 @@
+from typing import Literal, get_args
+
 import streamlit as st
 from htbuilder import a, img
 
-_SUPPORTED_TYPES = ("pypi", "streamlit", "github", "twitter", "buymeacoffee")
+_SUPPORTED_TYPES = Literal["pypi", "streamlit", "github", "twitter", "buymeacoffee"]
 
 
-def badge(type: str, name: str = None, url: str = None):
+def badge(type: _SUPPORTED_TYPES, name: str = None, url: str = None):
     """Easily create a badge!
 
     Args:
@@ -16,9 +18,9 @@ def badge(type: str, name: str = None, url: str = None):
 
     assert type, "Type must be given!"
 
-    assert type in _SUPPORTED_TYPES, (
+    assert type in get_args(_SUPPORTED_TYPES), (
         f"Input type '{type}' is not supported! Supported types are"
-        f" {_SUPPORTED_TYPES}"
+        f" {get_args(_SUPPORTED_TYPES)}"
     )
 
     badge_html = None


### PR DESCRIPTION
Make it easier to have playground demos work by support objects of type Literal