### PR TITLE
POC supporting multi-function extras

### DIFF
--- a/gallery/streamlit_app.py
+++ b/gallery/streamlit_app.py
@@ -207,14 +207,15 @@ def get_page_content(
         st.write("")
         st.write("## Docstring(s)")
         for func in funcs:
-            st.help(func)
-
-            with st.expander("Show me the full code!"):
+            st.write(f"### `{func.__name__}`")
+            with st.expander("Docstring"):
+                st.help(func)
+            with st.expander("Source code"):
                 st.code(inspect.getsource(func))
 
             if experimental_playground:
                 st.write("")
-                st.write("## Playground 🛝 [experimental]")
+                st.write("#### Playground 🛝 [experimental]")
                 st.caption("In this section, you can test the function live!")
                 function_explorer(func=func)
 

--- a/src/streamlit_extras/embed_code/__init__.py
+++ b/src/streamlit_extras/embed_code/__init__.py
@@ -20,7 +20,7 @@ def example_gitlab():
     gitlab_snippet(
         "https://gitlab.com/snippets/1995463",
         width=700,
-        height=400,
+        height=200,
     )
 
 

--- a/src/streamlit_extras/embed_code/__init__.py
+++ b/src/streamlit_extras/embed_code/__init__.py
@@ -1,4 +1,11 @@
-from streamlit_embedcode import github_gist
+from streamlit_embedcode import (
+    codepen_snippet,
+    github_gist,
+    gitlab_snippet,
+    ideone_snippet,
+    pastebin_snippet,
+    tagmycode_snippet,
+)
 
 
 def example_github():
@@ -9,11 +16,61 @@ def example_github():
     )
 
 
-__func__ = github_gist
+def example_gitlab():
+    gitlab_snippet(
+        "https://gitlab.com/snippets/1995463",
+        width=700,
+        height=400,
+    )
+
+
+def example_codepen(codepen_snippet):
+    codepen_snippet(
+        "https://codepen.io/randyzwitch/pen/GRrYrBw",
+        width=700,
+        height=400,
+    )
+
+
+def example_ideone(ideone_snippet):
+    ideone_snippet(
+        "https://ideone.com/5V7XZ6",
+        width=700,
+        height=400,
+    )
+
+
+def example_pastebin(pastebin_snippet):
+    pastebin_snippet(
+        "https://pastebin.com/8QZ7YjYD",
+        width=700,
+        height=400,
+    )
+
+
+def example_tagmycode(tagmycode_snippet):
+    tagmycode_snippet(
+        "https://tagmycode.com/snippet/1038",
+        width=700,
+        height=400,
+    )
+
+
+__funcs__ = [
+    github_gist,
+    gitlab_snippet,
+    codepen_snippet,
+    ideone_snippet,
+    pastebin_snippet,
+    tagmycode_snippet,
+]
 __title__ = "Embed code"
 __desc__ = "Embed code from various platforms (Gists, snippets...)"
 __icon__ = "📋"
-__examples__ = [example_github]
+__examples__ = {
+    example_github: [github_gist],
+    example_gitlab: [gitlab_snippet],
+}
 __author__ = "randyzwitch"
 __github_repo__ = "randyzwitch/streamlit-embedcode"
 __pypi_name__ = "streamlit-embedcode"

--- a/src/streamlit_extras/function_explorer/__init__.py
+++ b/src/streamlit_extras/function_explorer/__init__.py
@@ -34,7 +34,7 @@ def function_explorer(func: Callable):
     args = get_arg_details(func)
     inputs: Dict[str, Any] = dict()
 
-    st.write("#### Inputs")
+    st.write("##### Inputs")
     st.write(
         f"Go ahead and play with `{func.__name__}` parameters, see how"
         " they change the output!"
@@ -100,7 +100,7 @@ def function_explorer(func: Callable):
             else:
                 st.warning(f"`function_explorer` does not support type {type_hint}")
 
-    st.write("#### Output")
+    st.write("##### Output")
     func(**inputs)
     if func.__name__ not in st.session_state:
         st.session_state[func.__name__] = {}

--- a/tests/test_extras.py
+++ b/tests/test_extras.py
@@ -17,8 +17,19 @@ def test_extra_attributes(extra: str):
     assert type(mod.__title__) == str
     assert type(mod.__icon__) == str
     assert type(mod.__desc__) == str
-    assert callable(mod.__func__)
+    assert hasattr(mod, "__funcs__") or hasattr(mod, "__func__")
+    if hasattr(mod, "__funcs__"):
+        assert type(mod.__funcs__) == list
+        for func in mod.__funcs__:
+            assert callable(func)
+    else:
+        assert callable(mod.__func__)
     assert len(mod.__examples__) > 0
+    if type(mod.__examples__) == dict:
+        for example, funcs in mod.__examples__.items():
+            assert callable(example)
+            for func in funcs:
+                assert callable(func)
     assert type(mod.__author__) == str
     if hasattr(mod, "__inputs__"):
         assert type(mod.__inputs__) == dict

--- a/tests/test_extras.py
+++ b/tests/test_extras.py
@@ -22,6 +22,9 @@ def test_extra_attributes(extra: str):
         assert type(mod.__funcs__) == list
         for func in mod.__funcs__:
             assert callable(func)
+        # If you have multiple functions, then each example function must
+        # specify which of these functions must be imported
+        assert type(mod.__examples__) == dict
     else:
         assert callable(mod.__func__)
     assert len(mod.__examples__) > 0


### PR DESCRIPTION
Alters the API for an extra in two ways:

- `__func__` can optionally be `__funcs__`, a list of callables -- the gallery app just converts this to a list of length 1 if you use `__func__`
- `__examples__` can either be a list of callables, of a dictionary mapping callables to lists of callables. For example:

```python
__examples__ = {
    my_func: [import1, import2]
}
```
The reason for a list of callables is to specify the imports that are needed. So, in the gallery, the import line will look like this:

```python
from streamlit_extras.my_extra import import1, import2

# Code from my_func
```

WDYT?

If you think this looks good, we could go ahead and convert several of the extras into this multi-function style