### PR TITLE
Add extra() decorator

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,14 +9,15 @@ Head over to our public [repository](https://github.com/arnaudmiribel/streamlit-
 
     ```python
     # extras/<extra_name>/__init__.py
+    from .. import extra
 
+    @extra  # this will register your function's extra
     def my_main_function():
         ...
 
     def example():
         ...
 
-    __func__ = my_main_function  # main function of your extra!
     __title__ = "Great title!"  # title of your extra!
     __desc__ = "Great description"  # description of your extra!
     __icon__ = "🔭"  # give your extra an icon!
@@ -31,11 +32,13 @@ Head over to our public [repository](https://github.com/arnaudmiribel/streamlit-
     # extras/<extra_name>/__init__.py
 
     from my_package import my_main_function
+    from .. import extra
+
+    my_main_function = extra(my_main_function)
 
     def example():
         ...
 
-    __func__ = my_main_function  # main function of your extra!
     __title__ = "Great title!"  # title of your extra!
     __desc__ = "Great description"  # description of your extra!
     __icon__ = "🔭"  # give your extra an icon!

--- a/gallery/streamlit_app.py
+++ b/gallery/streamlit_app.py
@@ -230,10 +230,7 @@ for extra_name in extra_names:
     mod = import_module(f"streamlit_extras.{extra_name}")
     title = mod.__title__
     icon = mod.__icon__
-    if hasattr(mod, "__funcs__"):
-        funcs = mod.__funcs__
-    else:
-        funcs = [mod.__func__]
+    funcs = mod.__funcs__
     examples = mod.__examples__
     inputs = getattr(mod, "__inputs__", dict())
     desc = mod.__desc__

--- a/src/streamlit_extras/__init__.py
+++ b/src/streamlit_extras/__init__.py
@@ -1,0 +1,45 @@
+import inspect
+from importlib import import_module
+from typing import Any, Callable, Optional, TypeVar, Union, overload
+
+from streamlit import _gather_metrics
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+@overload
+def extra(
+    func: F,
+) -> F:
+    ...
+
+
+@overload
+def extra(
+    func: None = None,
+) -> Callable[[F], F]:
+    ...
+
+
+def extra(
+    func: Optional[F] = None,
+) -> Union[Callable[[F], F], F]:
+
+    if func:
+
+        filename = inspect.stack()[1].filename
+        extra_name = "streamlit_extras." + filename.split("/")[-2]
+        module = import_module(extra_name)
+
+        if hasattr(module, "__funcs__"):
+            module.__funcs__ += [func]  # type: ignore
+        else:
+            module.__funcs__ = [func]  # type: ignore
+
+        name = f"{module}.{func.__name__}"
+        return _gather_metrics(name=name, func=func)
+
+    def wrapper(f: F) -> F:
+        return f
+
+    return wrapper

--- a/src/streamlit_extras/altex/__init__.py
+++ b/src/streamlit_extras/altex/__init__.py
@@ -6,6 +6,8 @@ import numpy as np
 import pandas as pd
 import streamlit as st
 
+from .. import extra
+
 
 @st.experimental_memo
 def url_to_dataframe(url: str) -> pd.DataFrame:
@@ -120,6 +122,7 @@ def _get_spark_axis_config(
         raise TypeError("Input x/y must be of type str or alt.X or alt.Y")
 
 
+@extra
 def _chart(
     mark_function: str,
     data: pd.DataFrame,
@@ -464,7 +467,6 @@ def example_bar_grouped():
     )
 
 
-__funcs__ = [_chart]
 __title__ = "Altex"
 __desc__ = (
     "A simple wrapper on top of Altair to make Streamlit charts in an"

--- a/src/streamlit_extras/annotated_text/__init__.py
+++ b/src/streamlit_extras/annotated_text/__init__.py
@@ -1,5 +1,9 @@
 from annotated_text import annotated_text
 
+from .. import extra
+
+annotated_text = extra(annotated_text)
+
 
 def example_1():
     from annotated_text import annotated_text
@@ -28,7 +32,6 @@ def example_2():
     )
 
 
-__func__ = annotated_text
 __title__ = "Annotated text"
 __desc__ = "A simple way to display annotated text in Streamlit apps"
 __icon__ = "🖊️"

--- a/src/streamlit_extras/app_logo/__init__.py
+++ b/src/streamlit_extras/app_logo/__init__.py
@@ -1,7 +1,10 @@
 import streamlit as st
 import validators
 
+from .. import extra
 
+
+@extra
 def add_logo(logo_url: str):
     """Add a logo (from logo_url) on the top of the navigation page of a multipage app.
     Taken from https://discuss.streamlit.io/t/put-logo-and-title-above-on-top-of-page-navigation-in-sidebar-of-multipage-app/28213/6
@@ -32,7 +35,6 @@ def example():
     st.write("👈 Check out the cat in the nav-bar!")
 
 
-__func__ = add_logo
 __title__ = "App logo"
 __desc__ = "Add a logo on top of the navigation bar of a multipage app"
 __icon__ = "🐱"

--- a/src/streamlit_extras/badges/__init__.py
+++ b/src/streamlit_extras/badges/__init__.py
@@ -3,9 +3,12 @@ from typing import Literal, get_args
 import streamlit as st
 from htbuilder import a, img
 
+from .. import extra
+
 _SUPPORTED_TYPES = Literal["pypi", "streamlit", "github", "twitter", "buymeacoffee"]
 
 
+@extra
 def badge(type: _SUPPORTED_TYPES, name: str = None, url: str = None):
     """Easily create a badge!
 
@@ -101,7 +104,6 @@ def example_buymeacoffee():
     badge(type="buymeacoffee", name="andfanilo")
 
 
-__func__ = badge
 __title__ = "Badges"
 __desc__ = "Create custom badges (e.g. PyPI, Streamlit Cloud, GitHub, Twitter, Buy Me a Coffee)"
 __icon__ = "🏷️"

--- a/src/streamlit_extras/buy_me_a_coffee/__init__.py
+++ b/src/streamlit_extras/buy_me_a_coffee/__init__.py
@@ -3,6 +3,8 @@ from typing import Literal
 import streamlit as st
 from streamlit.components.v1 import html
 
+from .. import extra
+
 Font = Literal[
     "Cookie",
     "Lato",
@@ -14,6 +16,7 @@ Font = Literal[
 ]
 
 
+@extra
 def button(
     username: str,
     floating: bool = True,
@@ -61,7 +64,6 @@ def example():
     button(username="fake-username", floating=False, width=221)
 
 
-__func__ = button  # main function of your extra!
 __title__ = "Buy Me a Coffee Button"  # title of your extra!
 __desc__ = "Adds a floating button which links to your Buy Me a Coffee page"  # description of your extra!
 __icon__ = "☕"  # give your extra an icon!

--- a/src/streamlit_extras/camera_input_live/__init__.py
+++ b/src/streamlit_extras/camera_input_live/__init__.py
@@ -1,6 +1,10 @@
 import streamlit as st
 from camera_input_live import camera_input_live
 
+from .. import extra
+
+camera_input_live = extra(camera_input_live)
+
 
 def example():
     st.write("# See a new image every second")
@@ -10,7 +14,6 @@ def example():
         st.image(image)
 
 
-__func__ = camera_input_live
 __title__ = "Camera input live"
 __desc__ = "A camera input that updates a variable number of seconds"
 __icon__ = "📸"

--- a/src/streamlit_extras/chart_annotations/__init__.py
+++ b/src/streamlit_extras/chart_annotations/__init__.py
@@ -4,6 +4,8 @@ import altair as alt
 import pandas as pd
 import streamlit as st
 
+from .. import extra
+
 alt.themes.enable("streamlit")
 
 
@@ -57,6 +59,7 @@ def get_chart(data: pd.DataFrame) -> alt.Chart:
     return (lines + points + tooltips).interactive()
 
 
+@extra
 def get_annotations_chart(
     annotations: Iterable[Tuple],
     y: float = 0,
@@ -138,7 +141,6 @@ def example():
     st.altair_chart(chart, use_container_width=True)
 
 
-__func__ = get_annotations_chart
 __title__ = "Chart annotations"
 __desc__ = "Add annotations to specific timestamps in your time series in Altair!"
 __icon__ = "⬇"

--- a/src/streamlit_extras/colored_header/__init__.py
+++ b/src/streamlit_extras/colored_header/__init__.py
@@ -4,6 +4,8 @@ from typing import Literal
 
 import streamlit as st
 
+from .. import extra
+
 
 def color(name):
     """Returns a color from the streamlit color palette, e.g. red-100, as hex."""
@@ -155,6 +157,7 @@ _SUPPORTED_COLORS = Literal[
 ]
 
 
+@extra
 def colored_header(
     label: str = "Nice title",
     description: str = "Cool description",
@@ -183,7 +186,6 @@ def example():
     )
 
 
-__func__ = colored_header
 __title__ = "Color ya Headers"
 __desc__ = "This function makes headers much prettier in Streamlit"
 __icon__ = "🖌️"

--- a/src/streamlit_extras/customize_running/__init__.py
+++ b/src/streamlit_extras/customize_running/__init__.py
@@ -2,6 +2,8 @@ import time
 
 import streamlit as st
 
+from .. import extra
+
 center_css = """
 <style>
 
@@ -18,6 +20,7 @@ div[class*="StatusWidget"]{
 """
 
 
+@extra
 def center_running():
     st.markdown(center_css, unsafe_allow_html=True)
 
@@ -29,7 +32,6 @@ def example():
         time.sleep(2)
 
 
-__func__ = center_running
 __title__ = "Customize running"
 __desc__ = "Customize the running widget"
 __icon__ = "🏃‍♂️"

--- a/src/streamlit_extras/dataframe_explorer/__init__.py
+++ b/src/streamlit_extras/dataframe_explorer/__init__.py
@@ -9,7 +9,10 @@ from pandas.api.types import (
     is_object_dtype,
 )
 
+from .. import extra
 
+
+@extra
 def dataframe_explorer(df: pd.DataFrame) -> pd.DataFrame:
     """
     Adds a UI on top of a dataframe to let viewers filter columns
@@ -257,7 +260,6 @@ def example(df: pd.DataFrame):
     st.dataframe(filtered_df)
 
 
-__func__ = dataframe_explorer
 __title__ = "Dataframe explorer UI"
 __desc__ = (
     "Let your viewers explore dataframes themselves! Learn more about it on"

--- a/src/streamlit_extras/echo_expander/__init__.py
+++ b/src/streamlit_extras/echo_expander/__init__.py
@@ -4,11 +4,14 @@ import traceback
 
 import streamlit as st
 
+from .. import extra
+
 ###
 # Extension from echo() in streamlit/echo.py
 ###
 
 
+@extra
 @contextlib.contextmanager
 def echo_expander(code_location="above", expander=True, label="Show code"):
     """Use in a `with` block to draw some code on the app, then execute it.
@@ -113,7 +116,6 @@ def example2():
         st.dataframe(df)
 
 
-__func__ = echo_expander
 __title__ = "Echo Expander"
 __desc__ = "Execute code, and show the code that was executed, but in an expander."
 __icon__ = "🆒"

--- a/src/streamlit_extras/embed_code/__init__.py
+++ b/src/streamlit_extras/embed_code/__init__.py
@@ -7,6 +7,15 @@ from streamlit_embedcode import (
     tagmycode_snippet,
 )
 
+from .. import extra
+
+codepen_snippet = extra(codepen_snippet)
+github_gist = extra(github_gist)
+gitlab_snippet = extra(gitlab_snippet)
+ideone_snippet = extra(ideone_snippet)
+pastebin_snippet = extra(pastebin_snippet)
+tagmycode_snippet = extra(tagmycode_snippet)
+
 
 def example_github():
     github_gist(
@@ -56,14 +65,6 @@ def example_tagmycode(tagmycode_snippet):
     )
 
 
-__funcs__ = [
-    github_gist,
-    gitlab_snippet,
-    codepen_snippet,
-    ideone_snippet,
-    pastebin_snippet,
-    tagmycode_snippet,
-]
 __title__ = "Embed code"
 __desc__ = "Embed code from various platforms (Gists, snippets...)"
 __icon__ = "📋"

--- a/src/streamlit_extras/faker/__init__.py
+++ b/src/streamlit_extras/faker/__init__.py
@@ -1,5 +1,9 @@
 from streamlit_faker import get_streamlit_faker
 
+from .. import extra
+
+get_streamlit_faker = extra(get_streamlit_faker)
+
 
 def example():
     fake = get_streamlit_faker(seed=42)
@@ -11,7 +15,6 @@ def example():
     fake.altair_chart()
 
 
-__func__ = get_streamlit_faker
 __title__ = "Streamlit Faker"
 __desc__ = "Fake Streamlit commands at the speed of light! Great for prototyping apps."
 __icon__ = "🥷"

--- a/src/streamlit_extras/function_explorer/__init__.py
+++ b/src/streamlit_extras/function_explorer/__init__.py
@@ -5,6 +5,8 @@ import pandas as pd
 import streamlit as st
 from st_keyup import st_keyup
 
+from .. import extra
+
 
 def get_arg_details(func):
     signature = inspect.signature(func)
@@ -24,6 +26,7 @@ def get_arg_from_session_state(func_name: str, argument: str):
             return st.session_state[func_name]["inputs"][argument]
 
 
+@extra
 def function_explorer(func: Callable):
     """Gives a Streamlit UI to any function.
 
@@ -116,7 +119,6 @@ def example():
     function_explorer(foo)
 
 
-__func__ = function_explorer
 __title__ = "Function explorer"
 __desc__ = "Give a UI to any Python function! Very alpha though"
 __icon__ = "👩‍🚀"

--- a/src/streamlit_extras/image_in_tables/__init__.py
+++ b/src/streamlit_extras/image_in_tables/__init__.py
@@ -3,6 +3,8 @@ from typing import Iterable
 import pandas as pd
 import streamlit as st
 
+from .. import extra
+
 
 @st.experimental_memo
 def get_dataframe() -> pd.DataFrame:
@@ -36,6 +38,7 @@ def get_dataframe() -> pd.DataFrame:
     return df
 
 
+@extra
 @st.experimental_memo
 def table_with_images(df: pd.DataFrame, url_columns: Iterable):
 
@@ -62,7 +65,6 @@ def example(df: pd.DataFrame):
     st.markdown(df_html, unsafe_allow_html=True)
 
 
-__func__ = table_with_images
 __title__ = "Image in tables"
 __desc__ = "Transform URLs into images in your dataframes"
 __icon__ = "🚩"

--- a/src/streamlit_extras/keyboard_text/__init__.py
+++ b/src/streamlit_extras/keyboard_text/__init__.py
@@ -1,6 +1,8 @@
 import streamlit as st
 from htbuilder import span
 
+from .. import extra
+
 
 def load_key_css():
     st.write(
@@ -23,6 +25,7 @@ def load_key_css():
     )
 
 
+@extra
 def key(text: str, write: bool = True) -> str:
     """Applies a custom CSS to input text which makes it look like a keyboard key.
     To be used after running load_key_css() at least once in the app!
@@ -55,7 +58,6 @@ def example_inline():
     )
 
 
-__func__ = key
 __title__ = "Keyboard text"
 __desc__ = "Create a keyboard styled text"
 __icon__ = "⌨️"

--- a/src/streamlit_extras/keyboard_url/__init__.py
+++ b/src/streamlit_extras/keyboard_url/__init__.py
@@ -1,9 +1,11 @@
 import streamlit as st
 import streamlit.components.v1 as components
 
+from .. import extra
 from ..keyboard_text import key, load_key_css
 
 
+@extra
 def keyboard_to_url(
     key: str = None,
     key_code: int = None,
@@ -66,7 +68,6 @@ def example():
     )
 
 
-__func__ = keyboard_to_url
 __title__ = "Keyboard to URL"
 __desc__ = (
     "Create bindings so that hitting a key on your keyboard opens an URL in a"

--- a/src/streamlit_extras/let_it_rain/__init__.py
+++ b/src/streamlit_extras/let_it_rain/__init__.py
@@ -2,7 +2,10 @@ from typing import Union
 
 import streamlit as st
 
+from .. import extra
 
+
+@extra
 def rain(
     emoji: str,
     font_size: int = 64,
@@ -210,7 +213,6 @@ def example():
     )
 
 
-__func__ = rain
 __title__ = "Let emojis rain"
 __desc__ = "Use this to create more animations like st.balloons() and st.snow()"
 __icon__ = "🌧️"

--- a/src/streamlit_extras/mention/__init__.py
+++ b/src/streamlit_extras/mention/__init__.py
@@ -2,6 +2,8 @@ import streamlit as st
 from htbuilder import a, img, span
 from validators import url as validate_url
 
+from .. import extra
+
 GITHUB_ICON = "https://cdn-icons-png.flaticon.com/512/25/25231.png"
 NOTION_ICON = "https://upload.wikimedia.org/wikipedia/commons/4/45/Notion_app_logo.png"
 TWITTER_ICON = "https://seeklogo.com/images/T/twitter-icon-circle-blue-logo-0902F48837-seeklogo.com.png"
@@ -16,6 +18,7 @@ a:hover {
 """
 
 
+@extra
 def mention(label: str, url: str, icon: str = "🔗", write: bool = True):
     """Mention a link with a label and icon.
 
@@ -115,7 +118,6 @@ def example_5():
     )
 
 
-__func__ = mention
 __title__ = "Mentions"
 __desc__ = "Create nice links with icons, like Notion mentions!"
 __icon__ = "🫵"

--- a/src/streamlit_extras/st_keyup/__init__.py
+++ b/src/streamlit_extras/st_keyup/__init__.py
@@ -1,6 +1,10 @@
 import streamlit as st
 from st_keyup import st_keyup
 
+from .. import extra
+
+st_keyup = extra(st_keyup)
+
 
 def example():
     st.write("## Notice how the output doesn't update until you hit enter")
@@ -17,7 +21,6 @@ def example_with_debounce():
     st.write(out)
 
 
-__func__ = st_keyup
 __title__ = "Keyup text input"
 __desc__ = "A text input that updates with every key press"
 __icon__ = "🔑"

--- a/src/streamlit_extras/stodo/__init__.py
+++ b/src/streamlit_extras/stodo/__init__.py
@@ -1,6 +1,9 @@
 import streamlit as st
 
+from .. import extra
 
+
+@extra
 def to_do(st_commands, checkbox_id):
     """Create a to_do item
 
@@ -68,7 +71,6 @@ def example():
     )
 
 
-__func__ = to_do
 __title__ = "To-do items"
 __desc__ = "Simple Python function to create to-do items in Streamlit!"
 __icon__ = "✔️"

--- a/src/streamlit_extras/stoggle/__init__.py
+++ b/src/streamlit_extras/stoggle/__init__.py
@@ -2,7 +2,10 @@ import streamlit as st
 from htbuilder import details, div, p, styles
 from htbuilder import summary as smry
 
+from .. import extra
 
+
+@extra
 def stoggle(summary: str, content: str):
     """
     Displays a toggle widget in Streamlit
@@ -30,7 +33,6 @@ def example():
     )
 
 
-__func__ = stoggle
 __title__ = "Toggle button"
 __desc__ = "Toggle button just like in Notion!"
 __icon__ = "➡️"

--- a/src/streamlit_extras/switch_page_button/__init__.py
+++ b/src/streamlit_extras/switch_page_button/__init__.py
@@ -1,6 +1,9 @@
 import streamlit as st
 
+from .. import extra
 
+
+@extra
 def switch_page(page_name: str):
     from streamlit.runtime.scriptrunner import RerunData, RerunException
     from streamlit.source_util import get_pages
@@ -47,7 +50,6 @@ def test_switch_invalid_page():
         switch_page("non existent page")
 
 
-__func__ = switch_page
 __title__ = "Switch page function"
 __desc__ = "Function to switch page programmatically in a MPA"
 __icon__ = "🖱️"

--- a/src/streamlit_extras/toggle_switch/__init__.py
+++ b/src/streamlit_extras/toggle_switch/__init__.py
@@ -1,6 +1,10 @@
 import streamlit as st
 from streamlit_toggle import st_toggle_switch
 
+from .. import extra
+
+st_toggle_switch = extra(st_toggle_switch)
+
 
 def example():
     st.write("## Toggle Switch")
@@ -15,10 +19,9 @@ def example():
     )
 
 
-__func__ = st_toggle_switch  # main function of your extra!
 __title__ = "Toggle Switch"  # title of your extra!
 __desc__ = (
-    "On/Off Toggle Switch with color customizations"  # description of your extra!
+    "On/Off Toggle Switch with color custimizations"  # description of your extra!
 )
 __icon__ = "🔛"  # give your extra an icon!
 __examples__ = [example]  # create some examples to show how cool your extra is!

--- a/src/streamlit_extras/toggle_switch/__init__.py
+++ b/src/streamlit_extras/toggle_switch/__init__.py
@@ -21,7 +21,7 @@ def example():
 
 __title__ = "Toggle Switch"  # title of your extra!
 __desc__ = (
-    "On/Off Toggle Switch with color custimizations"  # description of your extra!
+    "On/Off Toggle Switch with color customizations"  # description of your extra!
 )
 __icon__ = "🔛"  # give your extra an icon!
 __examples__ = [example]  # create some examples to show how cool your extra is!

--- a/src/streamlit_extras/vertical_slider/__init__.py
+++ b/src/streamlit_extras/vertical_slider/__init__.py
@@ -1,6 +1,10 @@
 import streamlit as st
 from streamlit_vertical_slider import vertical_slider
 
+from .. import extra
+
+vertical_slider = extra(vertical_slider)
+
 
 def example():
     st.write("## Vertical Slider")
@@ -16,7 +20,6 @@ def example():
     )
 
 
-__func__ = vertical_slider  # main function of your extra!
 __title__ = "Vertical Slider"  # title of your extra!
 __desc__ = (
     "Continuous Vertical Slider with color customizations"  # description of your extra!

--- a/src/streamlit_extras/word_importances/__init__.py
+++ b/src/streamlit_extras/word_importances/__init__.py
@@ -2,7 +2,10 @@ from typing import List
 
 import streamlit as st
 
+from .. import extra
 
+
+@extra
 def format_word_importances(words: List[str], importances: List[float]) -> str:
     """Adds a background color to each word based on its importance (float from -1 to 1)
 
@@ -58,7 +61,6 @@ def example():
     st.write(html, unsafe_allow_html=True)
 
 
-__func__ = format_word_importances
 __title__ = "Word importances"
 __desc__ = "Highlight words based on their importances. Inspired from captum library."
 __icon__ = "❗"

--- a/tests/test_extras.py
+++ b/tests/test_extras.py
@@ -17,16 +17,14 @@ def test_extra_attributes(extra: str):
     assert type(mod.__title__) == str
     assert type(mod.__icon__) == str
     assert type(mod.__desc__) == str
-    assert hasattr(mod, "__funcs__") or hasattr(mod, "__func__")
-    if hasattr(mod, "__funcs__"):
-        assert type(mod.__funcs__) == list
-        for func in mod.__funcs__:
-            assert callable(func)
-        # If you have multiple functions, then each example function must
-        # specify which of these functions must be imported
+    assert hasattr(mod, "__funcs__")
+    assert type(mod.__funcs__) == list
+    for func in mod.__funcs__:
+        assert callable(func)
+    # If you have multiple functions, then each example function must
+    # specify which of these functions must be imported
+    if len(mod.__funcs__) > 1:
         assert type(mod.__examples__) == dict
-    else:
-        assert callable(mod.__func__)
     assert len(mod.__examples__) > 0
     if type(mod.__examples__) == dict:
         for example, funcs in mod.__examples__.items():


### PR DESCRIPTION
This PR proposes a first solution for #63
- Add a `extra()` decorator on top of extras instead of explicitely defining `__func__` or `__funcs__`. The decorator will add the extra in the `__funcs__` attribute and big win is the benefit from page profiling. We get rid of `__func__`
- Adapt tests
- Adapt contribution guidelines
- Adapt all extras to use this decorator (or simply the function when we're only importing an extra from elsewhere)