### PR TITLE
updated _gather_metrics import for streamlit version 1.14

### DIFF
--- a/src/streamlit_extras/__init__.py
+++ b/src/streamlit_extras/__init__.py
@@ -2,7 +2,7 @@ import inspect
 from importlib import import_module
 from typing import Any, Callable, Optional, TypeVar, Union, overload
 
-from streamlit import _gather_metrics
+from streamlit.runtime.metrics_util import gather_metrics as _gather_metrics
 
 F = TypeVar("F", bound=Callable[..., Any])
 


### PR DESCRIPTION
Newer version of streamlit requires import of _gather_metrics from streamlit.runtime.metrics_util instead of streamlit only.