### PR TITLE
Update data-testid as we recently changed it with a migration from Enzyme to React-Testing-Library needs

### DIFF
--- a/src/streamlit_extras/metric_cards/__init__.py
+++ b/src/streamlit_extras/metric_cards/__init__.py
@@ -41,6 +41,16 @@ def style_metric_cards(
                 {box_shadow_str}
             }}
         </style>
+        <style>
+            div[data-testid="metric-container"] {{
+                background-color: {background_color};
+                border: {border_size_px}px solid {border_color};
+                padding: 5% 5% 5% 10%;
+                border-radius: {border_radius_px}px;
+                border-left: 0.5rem solid {border_left_color} !important;
+                {box_shadow_str}
+            }}
+        </style>
         """,
         unsafe_allow_html=True,
     )

--- a/src/streamlit_extras/metric_cards/__init__.py
+++ b/src/streamlit_extras/metric_cards/__init__.py
@@ -32,7 +32,7 @@ def style_metric_cards(
     st.markdown(
         f"""
         <style>
-            div[data-testid="metric-container"] {{
+            div[data-testid="stMetric"] {{
                 background-color: {background_color};
                 border: {border_size_px}px solid {border_color};
                 padding: 5% 5% 5% 10%;

--- a/src/streamlit_extras/metric_cards/__init__.py
+++ b/src/streamlit_extras/metric_cards/__init__.py
@@ -32,16 +32,7 @@ def style_metric_cards(
     st.markdown(
         f"""
         <style>
-            div[data-testid="stMetric"] {{
-                background-color: {background_color};
-                border: {border_size_px}px solid {border_color};
-                padding: 5% 5% 5% 10%;
-                border-radius: {border_radius_px}px;
-                border-left: 0.5rem solid {border_left_color} !important;
-                {box_shadow_str}
-            }}
-        </style>
-        <style>
+            div[data-testid="stMetric"],
             div[data-testid="metric-container"] {{
                 background-color: {background_color};
                 border: {border_size_px}px solid {border_color};


### PR DESCRIPTION
The Streamlit team updated the data-testid and as a result, 1.28.0 streamlit release doesn't work with streamlit-extras as the data-testid changed. I tested it locally and looks like changing the data-testid, as i suspected, fixed the problem.
<img width="1728" alt="Screenshot 2023-11-01 at 4 10 28 PM" src="https://github.com/arnaudmiribel/streamlit-extras/assets/16749069/da88d97a-68b8-48c8-be9c-00f9783e3b5b">
