### PR TITLE
Fix issue with vertical alignment for grid

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "streamlit-extras"
-version = "0.3.5"
+version = "0.3.6"
 license = "Apache-2.0"
 description = "A library to discover, try, install and share Streamlit extras"
 authors = [

--- a/src/streamlit_extras/grid/__init__.py
+++ b/src/streamlit_extras/grid/__init__.py
@@ -93,9 +93,20 @@ def grid(
         key=f"grid_{vertical_align}",
         css_styles=[
             """
+div[data-testid="column"] > div[data-testid="stVerticalBlockBorderWrapper"] > div {
+height: 100%;
+}
+""",
+            """
 div[data-testid="column"] > div {
 height: 100%;
 }
+""",
+            f"""
+div[data-testid="column"] > div[data-testid="stVerticalBlockBorderWrapper"] > div > div[data-testid="stVerticalBlock"] > div.element-container {{
+    {"margin-top: auto;" if vertical_align in ["center", "bottom"] else ""}
+    {"margin-bottom: auto;" if vertical_align == "center" else ""}
+}}
 """,
             f"""
 div[data-testid="column"] > div > div[data-testid="stVerticalBlock"] > div.element-container {{


### PR DESCRIPTION
This PR fixes an issue with the row & grid extras with the most recent version of Streamlit. The vertical alignment didn't work correctly anymore with those versions.

Closes https://github.com/arnaudmiribel/streamlit-extras/issues/201