### PR TITLE
edit add_logo function

### DIFF
--- a/src/streamlit_extras/app_logo/__init__.py
+++ b/src/streamlit_extras/app_logo/__init__.py
@@ -8,28 +8,68 @@ from .. import extra
 
 
 @extra
-def add_logo(logo_url: str, height: int = 120):
-    """Add a logo (from logo_url) on the top of the navigation page of a multipage app.
-    Taken from [the Streamlit forum](https://discuss.streamlit.io/t/put-logo-and-title-above-on-top-of-page-navigation-in-sidebar-of-multipage-app/28213/6)
-    The url can either be a url to the image, or a local path to the image.
+def add_logo(logo_url: str, title: str = "", subtitle: str = "", height: int = 200, color: str = "black", switch_position: bool = False):
+    """Add a logo (and optionally a title and subtitle) on the top of the navigation page of a multipage app.
+    Is it possible to choose also the color and the position of both element, if above or below the Logo.
+    The url can either be a URL to the image or a local path to the image.
 
     Args:
         logo_url (str): URL/local path of the logo
+        title (str, optional): Title to be displayed above or below the logo, depending on switch_position.
+        subtitle (str, optional): Subtitle to be displayed below the name or above the logo, depending on switch_position.
+        height (int, optional): Height of the logo. Defaults to 200.
+        color (str, optional): Color of title and subtitle. Default to black.
+        switch_position (bool, optional): Switches the position of the logo and title if True. Defaults to False, so
+                                          first Title and later Logo, as order.
     """
 
-    if validators.url(logo_url) is True:
+    if validators.url(logo_url):
         logo = f"url({logo_url})"
     else:
+        # Convert the local image to a base64 string
         logo = f"url(data:image/png;base64,{base64.b64encode(Path(logo_url).read_bytes()).decode()})"
+
+    # Adjust padding-top based on whether title and subtitle are provided
+    padding_top = height + 70 if title or subtitle else height + 70
+
+    # Determine the position of the title and logo based on switch_position
+    title_top = "20px" if not switch_position else f"{height + 50}px"
+    logo_top = f"{height-70}px" if not switch_position else "20px"
 
     st.markdown(
         f"""
         <style>
             [data-testid="stSidebarNav"] {{
+                background-image: none;
+                padding-top: {padding_top}px;
+            }}
+            
+            [data-testid="stSidebarNav"]::before {{
+                content: "{title}\\A{subtitle}";
+                display: block;
+                position: absolute;
+                top: {title_top};
+                left: 0;
+                right: 0;
+                white-space: pre-wrap;
+                text-align: center;
+                color: {color};
+                font-size: 18px;
+                font-weight: bold;
+            }}
+            
+            [data-testid="stSidebarNav"]::after {{
+                content: "";
+                display: block;
+                position: absolute;
+                top: {logo_top};
+                left: 20px;
+                right: 20px;
+                height: {height}px;
                 background-image: {logo};
                 background-repeat: no-repeat;
-                padding-top: {height - 40}px;
-                background-position: 20px 20px;
+                background-size: contain;
+                background-position: center;
             }}
         </style>
         """,


### PR DESCRIPTION
This pull request introduces enhancements to the add_logo function, enabling users to:

1. Add a title and subtitle to the logo on the navigation page of a multipage app, providing a more informative and customized sidebar.
2. Specify the color of the title and subtitle, allowing for better visual integration with the app's theme.
3. Determine the position of the title and subtitle relative to the logo, with the option to display them either above or below the logo. This additional flexibility caters to different design preferences and requirements.

It's my first pull request, so sorry for any error in case :)