### PR TITLE
Update deprecated st.experimental_rerun() in stateful_button for st.rerun()

### DIFF
--- a/src/streamlit_extras/stateful_button/__init__.py
+++ b/src/streamlit_extras/stateful_button/__init__.py
@@ -23,7 +23,7 @@ def button(*args, key=None, **kwargs):
 
     if st.button(*args, **kwargs):
         st.session_state[key] = not st.session_state[key]
-        st.experimental_rerun()
+        st.rerun()
 
     return st.session_state[key]
 

--- a/src/streamlit_extras/stateful_button/__init__.py
+++ b/src/streamlit_extras/stateful_button/__init__.py
@@ -1,5 +1,10 @@
 import streamlit as st
 
+try:
+    from streamlit import rerun
+except ImportError:
+    from streamlit import experimental_rerun as rerun
+
 from .. import extra
 
 
@@ -23,7 +28,7 @@ def button(*args, key=None, **kwargs):
 
     if st.button(*args, **kwargs):
         st.session_state[key] = not st.session_state[key]
-        st.rerun()
+        rerun()
 
     return st.session_state[key]
 


### PR DESCRIPTION
This pull request subtitutes the method `st.experimental_rerun()` used in the extra **stateful_button** for its stable version `st.rerun()`.

This is asked in the issue #218 as the deprecated method logs a warning specifying that it will be removed soon (2024-04-01).