### PR TITLE
Add bottom container

### DIFF
--- a/src/streamlit_extras/bottom_container/__init__.py
+++ b/src/streamlit_extras/bottom_container/__init__.py
@@ -18,7 +18,9 @@ def bottom() -> DeltaGenerator:
     if hasattr(st, "_bottom"):
         return st._bottom
     else:
-        st.error("The bottom container is not supported in this Streamlit version.")
+        raise Exception(
+            "The bottom container is not supported in this Streamlit version."
+        )
 
 
 def example():

--- a/src/streamlit_extras/bottom_container/__init__.py
+++ b/src/streamlit_extras/bottom_container/__init__.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import streamlit as st
+
+from .. import extra
+
+if TYPE_CHECKING:
+    from streamlit.delta_generator import DeltaGenerator
+
+
+@extra
+def bottom() -> DeltaGenerator:
+    """
+    Insert a multi-element container that sticks to the bottom of the app.
+    """
+    if hasattr(st, "_bottom"):
+        return st._bottom
+    else:
+        st.error("The bottom container is not supported in this Streamlit version.")
+
+
+def example():
+    with bottom():
+        st.write("This is the bottom container")
+        st.text_input("This is a text input in the bottom container")
+
+
+__title__ = "Bottom Container"
+__desc__ = "A multi-element container that sticks to the bottom of the app."
+__icon__ = "⬇️"
+__examples__ = [example]
+__author__ = "Lukas Masuch"
+__experimental_playground__ = False

--- a/src/streamlit_extras/bottom_container/__init__.py
+++ b/src/streamlit_extras/bottom_container/__init__.py
@@ -22,6 +22,8 @@ def bottom() -> DeltaGenerator:
 
 
 def example():
+    st.write("This is the main container")
+
     with bottom():
         st.write("This is the bottom container")
         st.text_input("This is a text input in the bottom container")


### PR DESCRIPTION
This PR adds the bottom container, a multi-element container that sticks to the bottom of the app. This requires at least Streamlit 1.31.