### PR TITLE
updated the import of AtomiImage

### DIFF
--- a/src/streamlit_extras/stateful_chat/__init__.py
+++ b/src/streamlit_extras/stateful_chat/__init__.py
@@ -4,7 +4,7 @@ import time
 from typing import TYPE_CHECKING, Any, List, Sequence, Union
 
 import streamlit as st
-from streamlit.elements.image import AtomicImage
+from streamlit.elements.lib.image_utils import AtomicImage
 from streamlit.errors import StreamlitAPIException
 from typing_extensions import Literal, Required, TypedDict
 


### PR DESCRIPTION
I was about to make my own streamlit extra but I got an import error while trying to run gallery/streamlit_app.py.
My IDE fixed it automatically, I assume this is because of a streamlit refactoring. I couldn't find exactly when this change occurred, so I hope this pr is relevent.