### PR TITLE
Prefix chart_container download widget key

### DIFF
--- a/src/streamlit_extras/chart_container/__init__.py
+++ b/src/streamlit_extras/chart_container/__init__.py
@@ -64,7 +64,7 @@ def chart_container(
     if "chart_container_widget_key" not in st.session_state:
         st.session_state["chart_container_widget_key"] = 0
 
-    def _get_random_widget_key() -> str:
+    def _get_random_widget_key() -> int:
         st.session_state.chart_container_widget_key += 1
         return st.session_state.chart_container_widget_key
 
@@ -88,7 +88,7 @@ def chart_container(
                 data=exporter(export_data),
                 file_name="data" + extension,
                 mime=export_utils.get("mime"),
-                key=_get_random_widget_key(),
+                key=f"chart_container_download_{_get_random_widget_key()}",
             )
 
 


### PR DESCRIPTION
At my organization we are starting to log the entire `st.session_state`, to be able to link user actions to other metrics like resources consumption.

In that process I noticed several keys that were just integers, giving no clue to what widget they corresponded to:

```jsonc
"session_state": {
    "10": false,
    "11": false,
    "12": false,
    // ... other stuff from us
}
```

After investigation, I arrived at this repo, so I decided to attempt a PR.