### PR TITLE
Deprecate natively supported commands

### DIFF
--- a/docs/generate.py
+++ b/docs/generate.py
@@ -278,8 +278,10 @@ def generate_hash_for_playground_url(source_code: str) -> str:
 for extra_module_name in extra_modules_names:
     mod = import_module(f"streamlit_extras.{extra_module_name}")
     extra_metadata = get_extra_metadata(mod, extra_module_name)
-
-    full_doc_path = Path(f"extras/{extra_module_name}.md")
+    if extra_metadata.get("deprecated"):
+        full_doc_path = Path(f"extras_deprecated/{extra_module_name}.md")
+    else:
+        full_doc_path = Path(f"extras/{extra_module_name}.md")
 
     decorated_functions = extra_metadata.get("decorated_functions", [])
     extra_metadata["functions_docstrings"] = "--- \n".join(
@@ -312,7 +314,6 @@ for extra_module_name in extra_modules_names:
                 )
 
                 if extra_metadata["playground"]:
-
                     stlite_html = STLITE_HTML_TO_IFRAME.format(
                         code=STLITE_CODE.format(
                             extra_module_name=extra_module_name,

--- a/docs/generate.py
+++ b/docs/generate.py
@@ -247,6 +247,7 @@ def get_extra_metadata(module: ModuleType, module_name: str) -> dict:
             f"streamlit_extras.{module_name}"
         ),
         "playground": getattr(module, "__playground__", False),
+        "deprecated": getattr(module, "__deprecated__", False),
     }
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,7 +42,7 @@ nav:
   - Streamlit Components: components.md
   - Contributing: contributing.md
   - Browse Extras: extras/
-
+  - Deprecated Extras: extras_deprecated/
 
 markdown_extensions:
   - attr_list
@@ -60,4 +60,4 @@ markdown_extensions:
   - pymdownx.details
   - pymdownx.superfences
   - toc:
-      toc_depth : "3"
+      toc_depth: "3"

--- a/src/streamlit_extras/app_logo/__init__.py
+++ b/src/streamlit_extras/app_logo/__init__.py
@@ -46,8 +46,10 @@ def example():
 
 
 __title__ = "App logo"
-__desc__ = "Add a logo on top of the navigation bar of a multipage app"
+__desc__ = """Add a logo on top of the navigation bar of a multipage app.
+**Note:** [st.logo](https://docs.streamlit.io/develop/api-reference/media/st.logo) has been released in Streamlit 1.35.0!"""
 __icon__ = "🐱"
 __examples__ = [example]
 __author__ = "Zachary Blackwood"
 __playground__ = False
+__deprecated__ = True

--- a/src/streamlit_extras/button_selector/__init__.py
+++ b/src/streamlit_extras/button_selector/__init__.py
@@ -106,10 +106,13 @@ def example():
 
 
 __title__ = "Button Selector"
-__desc__ = (
-    "A button selector that can be used to select an item from a list of options."
-)
+__desc__ = """A button selector that can be used to select an item from a list of options.
+**Note:** [st.pills](https://docs.streamlit.io/develop/api-reference/widgets/st.pills) and
+[st.segmented_control](https://docs.streamlit.io/develop/api-reference/widgets/st.segmented_control)
+have been released in Streamlit 1.40.0!
+"""
 __icon__ = "🔢"
 __examples__ = [example]
 __author__ = "Zhijia Liu"
 __experimental_playground__ = False
+__deprecated__ = True

--- a/src/streamlit_extras/colored_header/__init__.py
+++ b/src/streamlit_extras/colored_header/__init__.py
@@ -1,4 +1,5 @@
 """Add colorful headers to your Streamlit app."""
+
 import itertools
 from typing import Literal
 
@@ -195,9 +196,10 @@ def example():
 
 __title__ = "Color ya Headers"
 __desc__ = """This function makes headers much prettier in Streamlit.
-           **Note that this now accessible in native Streamlit in st.header
-           with parameter `divider`!**"""
+           **Note:** this is now accessible in native Streamlit in [st.header](https://docs.streamlit.io/develop/api-reference/text/st.header)
+           with parameter `divider`!"""
 __icon__ = "🖌️"
 __examples__ = [example]
 __author__ = "Johannes Rieke / Tyler Richards"
 __playground__ = True
+__deprecated__ = True

--- a/src/streamlit_extras/concurrency_limiter/__init__.py
+++ b/src/streamlit_extras/concurrency_limiter/__init__.py
@@ -1,4 +1,5 @@
 """Add concurrency_limiter decorator to your Streamlit app."""
+
 from __future__ import annotations
 
 import hashlib
@@ -128,7 +129,7 @@ def example():
         heavy_computation()
 
 
-__title__ = "Concurrency limiter for your Streamlit app"
+__title__ = "Concurrency limiter "
 __desc__ = """This decorator limit function execution concurrency with max_concurrency param."""
 __icon__ = "🚦"
 __examples__ = [example]

--- a/src/streamlit_extras/grid/__init__.py
+++ b/src/streamlit_extras/grid/__init__.py
@@ -116,7 +116,7 @@ def example():
     my_grid.text_input("Your name")
     my_grid.button("Send", use_container_width=True)
     # Row 3:
-    my_grid.text_area("Your message", height=40)
+    my_grid.text_area("Your message", height=68)
     # Row 4:
     my_grid.button("Example 1", use_container_width=True)
     my_grid.button("Example 2", use_container_width=True)

--- a/src/streamlit_extras/grid/__init__.py
+++ b/src/streamlit_extras/grid/__init__.py
@@ -7,8 +7,6 @@ import pandas as pd
 import streamlit as st
 from streamlit.errors import StreamlitAPIException
 
-from streamlit_extras import stylable_container
-
 from .. import extra
 
 if TYPE_CHECKING:
@@ -24,6 +22,7 @@ class GridDeltaGenerator:
         spec: List[SpecType],
         *,
         gap: Optional[str] = "small",
+        vertical_align: Literal["top", "center", "bottom"] = "top",
         repeat: bool = True,
     ):
         self._parent_dg = parent_dg
@@ -32,6 +31,7 @@ class GridDeltaGenerator:
         self._spec = spec
         self._gap = gap
         self._repeat = repeat
+        self._vertical_align = vertical_align
 
     def _get_next_cell_container(self) -> "DeltaGenerator":
         if not self._container_queue:
@@ -41,7 +41,11 @@ class GridDeltaGenerator:
             # Create a new row using st.columns:
             self._number_of_rows += 1
             spec = self._spec[self._number_of_rows % len(self._spec) - 1]
-            self._container_queue.extend(self._parent_dg.columns(spec, gap=self._gap))
+            self._container_queue.extend(
+                self._parent_dg.columns(
+                    spec, gap=self._gap, vertical_alignment=self._vertical_align
+                )
+            )
 
         return self._container_queue.pop(0)
 
@@ -89,36 +93,13 @@ def grid(
             Defaults to "top".
     """
 
-    container = stylable_container.stylable_container(
-        key=f"grid_{vertical_align}",
-        css_styles=[
-            """
-div[data-testid="column"] > div[data-testid="stVerticalBlockBorderWrapper"] > div {
-height: 100%;
-}
-""",
-            """
-div[data-testid="column"] > div {
-height: 100%;
-}
-""",
-            f"""
-div[data-testid="column"] > div[data-testid="stVerticalBlockBorderWrapper"] > div > div[data-testid="stVerticalBlock"] > div.element-container {{
-    {"margin-top: auto;" if vertical_align in ["center", "bottom"] else ""}
-    {"margin-bottom: auto;" if vertical_align == "center" else ""}
-}}
-""",
-            f"""
-div[data-testid="column"] > div > div[data-testid="stVerticalBlock"] > div.element-container {{
-    {"margin-top: auto;" if vertical_align in ["center", "bottom"] else ""}
-    {"margin-bottom: auto;" if vertical_align == "center" else ""}
-}}
-""",
-        ],
-    )
-
+    container = st.container()
     return GridDeltaGenerator(
-        parent_dg=container, spec=list(spec), gap=gap, repeat=True
+        parent_dg=container,
+        spec=list(spec),
+        gap=gap,
+        repeat=True,
+        vertical_align=vertical_align,
     )
 
 

--- a/src/streamlit_extras/image_in_tables/__init__.py
+++ b/src/streamlit_extras/image_in_tables/__init__.py
@@ -83,8 +83,9 @@ def example(df: pd.DataFrame):
 
 
 __title__ = "Image in tables"
-__desc__ = """Transform URLs into images in your dataframes. **Note: you should now use
-st.column_config.ImageColumn straight within the native st.dataframe!** """
+__desc__ = """Transform URLs into images in your dataframes.
+**Note:** you should now use [st.column_config.ImageColumn](https://docs.streamlit.io/develop/api-reference/data/st.column_config/st.column_config.imagecolumn)
+straight within the native st.dataframe! Or you can put markdown in `st.table` cells."""
 __icon__ = "🚩"
 __examples__ = [example]
 __inputs__ = dict(df=df)
@@ -94,3 +95,4 @@ __streamlit_cloud_url__ = (
 )
 __github_repo__ = "dataprofessor/st-demo-image-table"
 __playground__ = False
+__deprecated__ = True

--- a/src/streamlit_extras/no_default_selectbox/__init__.py
+++ b/src/streamlit_extras/no_default_selectbox/__init__.py
@@ -88,3 +88,4 @@ __icon__ = "🗳️"
 __examples__ = [example]
 __author__ = "Zachary Blackwood"
 __playground__ = True
+__deprecated__ = True

--- a/src/streamlit_extras/row/__init__.py
+++ b/src/streamlit_extras/row/__init__.py
@@ -4,8 +4,9 @@ from typing import Literal, Optional, Sequence, Union
 
 import numpy as np
 import pandas as pd
+import streamlit as st
 
-from streamlit_extras import grid, stylable_container
+from streamlit_extras import grid
 
 from .. import extra
 
@@ -47,24 +48,11 @@ def row(
             A row container object. Elements can be added to this row by calling methods directly
             on the returned object.
     """
-    container = stylable_container.stylable_container(
-        key=f"row_{vertical_align}",
-        css_styles=[
-            """
-div[data-testid="column"] > div {
-height: 100%;
-}
-""",
-            f"""
-div[data-testid="column"] > div > div[data-testid="stVerticalBlock"] > div.element-container {{
-    {"margin-top: auto;" if vertical_align in ["center", "bottom"] else ""}
-    {"margin-bottom: auto;" if vertical_align == "center" else ""}
-}}
-""",
-        ],
-    )
+    container = st.container()
 
-    return grid.GridDeltaGenerator(parent_dg=container, spec=[spec], gap=gap)
+    return grid.GridDeltaGenerator(
+        parent_dg=container, spec=[spec], gap=gap, vertical_align=vertical_align
+    )
 
 
 def example():

--- a/src/streamlit_extras/streaming_write/__init__.py
+++ b/src/streamlit_extras/streaming_write/__init__.py
@@ -127,8 +127,9 @@ non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 
 __title__ = "Streaming Write"
 __desc__ = """Drop-in replacement for `st.write` with streaming support.
-**Note:** `st.write_stream` was released in Streamlit 1.31.0!"""
+**Note:** [st.write_stream](https://docs.streamlit.io/develop/api-reference/write-magic/st.write_stream) was released in Streamlit 1.31.0!"""
 __icon__ = "🌊"
 __examples__ = [example]
 __author__ = "Lukas Masuch"
 __playground__ = True
+__deprecated__ = True

--- a/src/streamlit_extras/stylable_container/__init__.py
+++ b/src/streamlit_extras/stylable_container/__init__.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 @extra
 def stylable_container(key: str, css_styles: str | list[str]) -> "DeltaGenerator":
-    """List
+    """
     Insert a container into your app which you can style using CSS.
     This is useful to style specific elements in your app.
 
@@ -34,14 +34,14 @@ def stylable_container(key: str, css_styles: str | list[str]) -> "DeltaGenerator
     if isinstance(css_styles, str):
         css_styles = [css_styles]
 
-        # Remove unneeded spacing that is added by the html:
-        css_styles.append(
-            """
+    # Remove unneeded spacing that is added by the html:
+    css_styles.append(
+        """
 > div:first-child {
-    margin-bottom: -1rem;
+margin-bottom: -1rem;
 }
 """
-        )
+    )
 
     style_text = """
 <style>

--- a/src/streamlit_extras/stylable_container/__init__.py
+++ b/src/streamlit_extras/stylable_container/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List
+import re
+from typing import TYPE_CHECKING
 
 import streamlit as st
 
@@ -11,8 +12,8 @@ if TYPE_CHECKING:
 
 
 @extra
-def stylable_container(key: str, css_styles: str | List[str]) -> "DeltaGenerator":
-    """
+def stylable_container(key: str, css_styles: str | list[str]) -> "DeltaGenerator":
+    """List
     Insert a container into your app which you can style using CSS.
     This is useful to style specific elements in your app.
 
@@ -26,17 +27,21 @@ def stylable_container(key: str, css_styles: str | List[str]) -> "DeltaGenerator
         DeltaGenerator: A container object. Elements can be added to this container using either the 'with'
             notation or by calling methods directly on the returned object.
     """
+
+    class_name = re.sub(r"[^a-zA-Z0-9_-]", "-", key.strip())
+    class_name = f"st-key-{class_name}"
+
     if isinstance(css_styles, str):
         css_styles = [css_styles]
 
-    # Remove unneeded spacing that is added by the style markdown:
-    css_styles.append(
-        """
+        # Remove unneeded spacing that is added by the html:
+        css_styles.append(
+            """
 > div:first-child {
     margin-bottom: -1rem;
 }
 """
-    )
+        )
 
     style_text = """
 <style>
@@ -45,18 +50,15 @@ def stylable_container(key: str, css_styles: str | List[str]) -> "DeltaGenerator
     for style in css_styles:
         style_text += f"""
 
-div[data-testid="stVerticalBlock"]:has(> div.element-container > div.stMarkdown > div[data-testid="stMarkdownContainer"] > p > span.{key}) {style}
-
+.st-key-{class_name} {style}
 """
 
-    style_text += f"""
+    style_text += """
     </style>
-
-<span class="{key}"></span>
 """
 
-    container = st.container()
-    container.markdown(style_text, unsafe_allow_html=True)
+    container = st.container(key=class_name)
+    container.html(style_text)
     return container
 
 
@@ -89,8 +91,11 @@ def example():
 
 
 __title__ = "Styleable Container"
-__desc__ = "A container that allows to style its child elements using CSS."
+__desc__ = """A container that allows to style its child elements using CSS.
+**Note:** the `key` argument in [st.container](https://docs.streamlit.io/develop/api-reference/layout/st.container)
+gets added as class name to the container. This is the preferred way to apply CSS styles for specific elements in Streamlit."""
 __icon__ = "🎨"
 __examples__ = [example]
 __author__ = "Lukas Masuch"
 __playground__ = False
+__deprecated__ = True

--- a/src/streamlit_extras/switch_page_button/__init__.py
+++ b/src/streamlit_extras/switch_page_button/__init__.py
@@ -68,8 +68,9 @@ def test_switch_invalid_page():
 
 __title__ = "Switch page function"
 __desc__ = """Function to switch page programmatically in a MPA.
-**Note:** st.switch_page is now part of the Streamlit core API!"""
+**Note:** [st.switch_page](https://docs.streamlit.io/develop/api-reference/navigation/st.switch_page) has been released in Streamlit 1.37.0!"""
 __icon__ = "🖱️"
 __examples__ = [example]
 __author__ = "Zachary Blackwood"
 __tests__ = [test_switch_page, test_switch_invalid_page]
+__deprecated__ = True

--- a/src/streamlit_extras/toggle_switch/__init__.py
+++ b/src/streamlit_extras/toggle_switch/__init__.py
@@ -20,9 +20,8 @@ def example():
 
 
 __title__ = "Toggle Switch"  # title of your extra!
-__desc__ = """On/Off Toggle Switch with color customizations. **Note
-    that this is now available as a native Streamlit command st.toggle.
-    Check out the [docs](https://docs.streamlit.io/library/api-reference/widgets/st.toggle)!**"""  # description of your extra!
+__desc__ = """On/Off Toggle Switch with color customizations.
+    **Note:** [st.toggle](https://docs.streamlit.io/library/api-reference/widgets/st.toggle) has been released in Streamlit 1.26.0!"""
 __icon__ = "🔛"  # give your extra an icon!
 __examples__ = [example]  # create some examples to show how cool your extra is!
 __author__ = "Carlos D. Serrano"
@@ -31,3 +30,4 @@ __package_name__ = "streamlit_toggle"
 __github_repo__ = "sqlinsights/streamlit-toggle-switch"  # Optional
 __forum_url__ = "https://discuss.streamlit.io/t/streamlit-toggle-switch/32474"
 __playground__ = True
+__deprecated__ = True


### PR DESCRIPTION
Deprecates a couple of natively supported commands and updates `stylable_container` / `row`/ `grid` to use native features instead of CSS hacks.

This also introduces a `__deprecated__` to mark extras as deprecated. This moves all the deprecated extras into a dedicate category on the documentation:
![image](https://github.com/user-attachments/assets/ee426fc3-592d-40d3-a835-2452436ff62a)

We could also think about showing a deprecation warning via: `show_deprecation_warning()` from Streamlit.
