### PR TITLE
Enable stlite sharedWorker mode to reduce memory consumption

### DIFF
--- a/docs/generate.py
+++ b/docs/generate.py
@@ -42,6 +42,7 @@ STLITE_HTML_TO_IFRAME = """
       }}
       stlite.mount(
   {{
+    sharedWorker: true,
     requirements: ["streamlit", "streamlit-extras"], // Packages to install
     entrypoint: "streamlit_app.py",
     files: {{


### PR DESCRIPTION
## Summary
- Enables sharedWorker mode in stlite.mount() configuration to reduce memory consumption when multiple stlite apps are embedded on a single page

## Context
When multiple stlite apps are embedded in the documentation pages, memory consumption grows very high. The sharedWorker mode allows multiple stlite instances to share the same Python environment, significantly reducing memory usage.

## Changes
- Added `sharedWorker: true` to the stlite.mount() configuration in `docs/generate.py`