### PR TITLE
Updated the floating button bottom position to make it non overlapping with st.chat_input

### DIFF
--- a/src/streamlit_extras/floating_button/__init__.py
+++ b/src/streamlit_extras/floating_button/__init__.py
@@ -80,7 +80,7 @@ def floating_button(
         <style>
             .st-key-{key} button {{
                 position: fixed;
-                bottom: 3.5rem;
+                bottom: 7.5rem;
                 right: 3.5rem;
                 min-width: 3.5rem;
                 min-height: 3.5rem;


### PR DESCRIPTION
This PR fixes the overlapping behaviour of the floating button on the streamlit's chat input. The PR is also compatible with the streamlit v1.53