### PR TITLE
Add on_change parameter to image_compare_slider

### DIFF
--- a/src/streamlit_extras/image_compare_slider/__init__.py
+++ b/src/streamlit_extras/image_compare_slider/__init__.py
@@ -21,6 +21,7 @@ from streamlit.errors import StreamlitAPIException
 from streamlit_extras import extra
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from io import BytesIO
     from pathlib import Path
 
@@ -76,8 +77,9 @@ def image_compare_slider(
     portrait: bool = False,
     height: Literal["content"] | int = "content",
     width: Literal["stretch", "content"] | int = "stretch",
+    on_change: Literal["ignore", "rerun"] | Callable[[], None] = "ignore",
     key: str | None = None,
-) -> float:
+) -> float | None:
     """Display an interactive image comparison slider.
 
     Overlays two images with a draggable divider that reveals portions of each.
@@ -96,10 +98,15 @@ def image_compare_slider(
             aspect ratio. Integer sets fixed pixel height.
         width: Component width. "stretch" (default) fills container width.
             "content" sizes to fit content. Integer sets fixed pixel width.
+        on_change: Controls behavior when the slider position changes.
+            "ignore" (default): No rerun, returns None.
+            "rerun": Triggers a script rerun, returns the current position.
+            Callable: Calls the provided callback function, returns the current position.
         key: Unique key for this component instance.
 
     Returns:
-        Current slider position as a value between 0 and 1.
+        Current slider position as a value between 0 and 1 when on_change is
+        "rerun" or a callable. Returns None when on_change is "ignore".
 
     Raises:
         StreamlitAPIException: If position is not between 0 and 1.
@@ -155,10 +162,13 @@ def image_compare_slider(
     # Convert position to percentage (0-100) for the frontend
     position_percent = position * 100
 
-    component = _get_component()
-    result = component(
-        key=key,
-        data={
+    # Determine if we should track position changes
+    track_position = on_change != "ignore"
+
+    # Build component kwargs
+    component_kwargs: dict[str, Any] = {
+        "key": key,
+        "data": {
             "image1_url": image1_url,
             "image2_url": image2_url,
             "label1": label1 or "",
@@ -167,12 +177,26 @@ def image_compare_slider(
             "height": height,
             "width": width,
             "initial_position": position_percent,
+            "track_position": track_position,
         },
-        default={"position": position_percent},
-        on_position_change=_on_position_change,
-        height=height,
-        width=width,
-    )
+        "height": height,
+        "width": width,
+    }
+
+    # Only add callback and default if tracking position
+    if track_position:
+        component_kwargs["default"] = {"position": position_percent}
+        if callable(on_change):
+            component_kwargs["on_position_change"] = on_change
+        else:  # on_change == "rerun"
+            component_kwargs["on_position_change"] = _on_position_change
+
+    component = _get_component()
+    result = component(**component_kwargs)
+
+    # Return None when ignoring changes, otherwise return the position
+    if on_change == "ignore":
+        return None
 
     # Get the current position from the result (in percentage) and convert to 0-1
     current_position_percent: float = result.get("position", position_percent)
@@ -186,14 +210,14 @@ def example_basic() -> None:
     st.write("### Basic Comparison")
     st.write("Drag the slider to compare the two images.")
 
-    position = image_compare_slider(
+    image_compare_slider(
         "https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800",
         "https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&sat=-100",
         label1="Color",
         label2="Grayscale",
         key="basic_compare",
     )
-    st.write(f"Slider position: **{position:.2f}**")
+    st.write("By default, the slider doesn't trigger reruns.")
 
 
 def example_portrait() -> None:
@@ -223,7 +247,24 @@ def example_custom_position() -> None:
         label1="Normal",
         label2="High Contrast",
         position=start_pos,
+        key="custom_position",
     )
+
+
+def example_track_position() -> None:
+    """Track slider position with on_change."""
+    st.write("### Track Position")
+    st.write("Use `on_change='rerun'` to get the current slider position.")
+
+    position = image_compare_slider(
+        "https://images.unsplash.com/photo-1682687220742-aba13b6e50ba?w=600",
+        "https://images.unsplash.com/photo-1682687220742-aba13b6e50ba?w=600&blur=10",
+        label1="Sharp",
+        label2="Blurred",
+        on_change="rerun",
+        key="track_position",
+    )
+    st.write(f"Slider position: **{position:.2f}**")
 
 
 __title__ = "Image Compare Slider"
@@ -233,6 +274,7 @@ __examples__ = [
     example_basic,
     example_portrait,
     example_custom_position,
+    example_track_position,
 ]
 __author__ = "Lukas Masuch"
 __created_at__ = date(2026, 4, 9)

--- a/src/streamlit_extras/image_compare_slider/__init__.py
+++ b/src/streamlit_extras/image_compare_slider/__init__.py
@@ -162,6 +162,10 @@ def image_compare_slider(
     # Convert position to percentage (0-100) for the frontend
     position_percent = position * 100
 
+    # Validate on_change parameter
+    if on_change not in ("ignore", "rerun") and not callable(on_change):
+        raise StreamlitAPIException(f"on_change must be 'ignore', 'rerun', or a callable, got {on_change!r}.")
+
     # Determine if we should track position changes
     track_position = on_change != "ignore"
 
@@ -264,6 +268,7 @@ def example_track_position() -> None:
         on_change="rerun",
         key="track_position",
     )
+    assert position is not None
     st.write(f"Slider position: **{position:.2f}**")
 
 

--- a/src/streamlit_extras/image_compare_slider/frontend/src/ImageCompareSlider.tsx
+++ b/src/streamlit_extras/image_compare_slider/frontend/src/ImageCompareSlider.tsx
@@ -182,6 +182,14 @@ const ImageCompareSlider: FC<ImageCompareSliderProps> = ({
     };
   }, []);
 
+  // Clear pending debounce timer when tracking is disabled
+  useEffect(() => {
+    if (!trackPosition && debounceTimerRef.current !== null) {
+      clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = null;
+    }
+  }, [trackPosition]);
+
   // Calculate height based on image aspect ratio if height is "content"
   // Uses ResizeObserver to handle container width changes
   useEffect(() => {

--- a/src/streamlit_extras/image_compare_slider/frontend/src/ImageCompareSlider.tsx
+++ b/src/streamlit_extras/image_compare_slider/frontend/src/ImageCompareSlider.tsx
@@ -27,6 +27,7 @@ export type ImageCompareSliderDataShape = {
   height: "content" | number;
   width: "content" | "stretch" | number;
   initial_position: number;
+  track_position: boolean;
 };
 
 export type ImageCompareSliderProps = Pick<
@@ -41,6 +42,7 @@ export type ImageCompareSliderProps = Pick<
   portrait: boolean;
   height: "content" | number;
   width: "content" | "stretch" | number;
+  trackPosition: boolean;
 };
 
 // Typed global Window interface for Streamlit
@@ -138,6 +140,7 @@ const ImageCompareSlider: FC<ImageCompareSliderProps> = ({
   portrait,
   height,
   width,
+  trackPosition,
   setStateValue,
 }): ReactElement => {
   const [position, setPosition] = useState(initialPosition);
@@ -146,10 +149,13 @@ const ImageCompareSlider: FC<ImageCompareSliderProps> = ({
   );
   const containerRef = useRef<HTMLDivElement>(null);
 
-  // Refs for throttled position updates
+  // Refs for debounced position updates
   const pendingPositionRef = useRef<number | null>(null);
-  const positionFrameRef = useRef<number | null>(null);
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastCommittedPositionRef = useRef<number>(position);
+
+  // Debounce delay in milliseconds
+  const DEBOUNCE_DELAY = 150;
 
   // Resolve media URLs
   const resolvedImage1Url = useMemo(
@@ -167,11 +173,11 @@ const ImageCompareSlider: FC<ImageCompareSliderProps> = ({
     lastCommittedPositionRef.current = initialPosition;
   }, [initialPosition]);
 
-  // Cleanup for position frame on unmount
+  // Cleanup for debounce timer on unmount
   useEffect(() => {
     return () => {
-      if (positionFrameRef.current !== null) {
-        cancelAnimationFrame(positionFrameRef.current);
+      if (debounceTimerRef.current !== null) {
+        clearTimeout(debounceTimerRef.current);
       }
     };
   }, []);
@@ -225,21 +231,27 @@ const ImageCompareSlider: FC<ImageCompareSliderProps> = ({
     };
   }, [height, resolvedImage1Url]);
 
-  // Handle position change with throttling via requestAnimationFrame
+  // Handle position change with debouncing to prevent rapid reruns
   const handlePositionChange = useCallback(
     (newPosition: number) => {
       // Clamp position to [0, 100] without rounding for smooth dragging
       const clampedPosition = Math.min(100, Math.max(0, newPosition));
       setPosition(clampedPosition);
-      pendingPositionRef.current = clampedPosition;
 
-      // Throttle state updates to avoid excessive reruns
-      if (positionFrameRef.current !== null) {
+      // Only send state updates if tracking is enabled
+      if (!trackPosition) {
         return;
       }
 
-      positionFrameRef.current = requestAnimationFrame(() => {
-        positionFrameRef.current = null;
+      pendingPositionRef.current = clampedPosition;
+
+      // Debounce state updates to avoid excessive reruns
+      if (debounceTimerRef.current !== null) {
+        clearTimeout(debounceTimerRef.current);
+      }
+
+      debounceTimerRef.current = setTimeout(() => {
+        debounceTimerRef.current = null;
 
         if (
           pendingPositionRef.current !== null &&
@@ -248,9 +260,9 @@ const ImageCompareSlider: FC<ImageCompareSliderProps> = ({
           lastCommittedPositionRef.current = pendingPositionRef.current;
           setStateValue("position", pendingPositionRef.current);
         }
-      });
+      }, DEBOUNCE_DELAY);
     },
-    [setStateValue],
+    [setStateValue, trackPosition],
   );
 
   // Container styles

--- a/src/streamlit_extras/image_compare_slider/frontend/src/index.tsx
+++ b/src/streamlit_extras/image_compare_slider/frontend/src/index.tsx
@@ -49,6 +49,7 @@ const ImageCompareSliderRoot: FrontendRenderer<
     height,
     width,
     initial_position,
+    track_position,
   } = data;
 
   // Render/re-render the React application into the root using the React DOM
@@ -65,6 +66,7 @@ const ImageCompareSliderRoot: FrontendRenderer<
         portrait={portrait}
         height={height}
         width={width}
+        trackPosition={track_position}
       />
     </StrictMode>,
   );


### PR DESCRIPTION
## Summary
- Adds `on_change` parameter to control rerun behavior: `"ignore"` (default), `"rerun"`, or a callback function
- Default behavior now prevents reruns when dragging the slider, returning `None`
- Frontend uses 150ms debounce to prevent rapid reruns when tracking is enabled
- Added new example demonstrating position tracking with `on_change="rerun"`

## Test plan