### PR TITLE
Bump version to 1.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "streamlit-extras"
-version = "1.3.0"
+version = "1.4.1"
 license = "Apache-2.0"
 description = "A community-driven collection of useful Streamlit components and utilities that extend Streamlit's functionality."
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -1494,7 +1494,7 @@ wheels = [
 
 [[package]]
 name = "streamlit-extras"
-version = "1.3.0"
+version = "1.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "plotly" },


### PR DESCRIPTION
## Summary
- Bumps package version from 1.3.0 to 1.4.1 in pyproject.toml
- Updates uv.lock to reflect the new version

## Test plan
- [ ] Verify the package installs correctly with the new version