### PR TITLE
Add `chartjs_chart` extra for Chart.js visualizations

### DIFF
--- a/src/streamlit_extras/AGENTS.md
+++ b/src/streamlit_extras/AGENTS.md
@@ -44,6 +44,7 @@ Use this guide to select the appropriate implementation approach:
 | `capture` | Capture utility extensions for Streamlit | pure python |
 | `chart_annotations` | Add annotations to Altair time series charts | pure python |
 | `chart_container` | Embed charts in tabs with data exploration | pure python |
+| `chartjs_chart` | Display charts using the Chart.js library | components v2: react |
 | `colored_header` | Create colorful, styled headers | st.html |
 | `concurrency_limiter` | Limit function execution concurrency | pure python |
 | `cookie_manager` | Read/write browser cookies from Python | components v2: inline |

--- a/src/streamlit_extras/chartjs_chart/__init__.py
+++ b/src/streamlit_extras/chartjs_chart/__init__.py
@@ -1,0 +1,195 @@
+"""Chart.js chart element for Streamlit.
+
+Display charts using the Chart.js library with Streamlit theme integration.
+Chart.js is known for its simplicity, lightweight footprint (~60KB gzipped),
+and beautiful out-of-the-box charts with smooth animations.
+"""
+
+from datetime import date
+from functools import cache
+from typing import Any, Literal
+
+import streamlit as st
+import streamlit.components.v2
+import streamlit.errors
+
+from streamlit_extras import extra
+
+
+@cache
+def _get_component() -> Any:
+    """Lazily initialize the CCv2 component.
+
+    Returns:
+        The component callable.
+    """
+    return streamlit.components.v2.component(
+        "streamlit-extras.chartjs_chart",
+        js="index-*.js",
+        html='<div class="react-root"></div>',
+    )
+
+
+@extra
+def chartjs_chart(
+    spec: dict[str, Any],
+    *,
+    height: Literal["content", "stretch"] | int = "content",
+    theme: Literal["streamlit"] | None = "streamlit",
+    key: str | None = None,
+) -> None:
+    """Display a chart using Chart.js.
+
+    Chart.js is a popular JavaScript charting library known for its simplicity,
+    performance, and smooth animations. This function renders a Chart.js chart
+    from a configuration dictionary.
+
+    Args:
+        spec: Chart.js configuration object containing `type`, `data`, and optionally
+            `options`. See Chart.js documentation for the full specification.
+            Supported chart types: bar, line, pie, doughnut, radar, polarArea,
+            bubble, scatter.
+        height: Chart height. "content": fit to content (default). "stretch": fill
+            container height. int: fixed pixel height.
+        theme: Theme for the chart. "streamlit": use Streamlit theme colors for
+            datasets, fonts, and grid (default). None: use Chart.js defaults.
+        key: Unique key for this chart instance.
+
+    Raises:
+        StreamlitAPIException: If spec is not a dict or missing required fields.
+
+    Example:
+        ```python
+        from streamlit_extras.chartjs_chart import chartjs_chart
+
+        spec = {
+            "type": "bar",
+            "data": {
+                "labels": ["January", "February", "March", "April", "May"],
+                "datasets": [{"label": "Sales", "data": [65, 59, 80, 81, 56]}],
+            },
+        }
+        chartjs_chart(spec)
+        ```
+    """
+    # Validate spec is a dict
+    if not isinstance(spec, dict):
+        raise streamlit.errors.StreamlitAPIException(f"spec must be a dict, got {type(spec).__name__}")
+
+    # Validate required spec fields
+    if "type" not in spec:
+        raise streamlit.errors.StreamlitAPIException(
+            "spec must contain a 'type' field specifying the chart type (e.g., 'bar', 'line', 'pie')"
+        )
+
+    valid_types = {"bar", "line", "pie", "doughnut", "radar", "polarArea", "bubble", "scatter"}
+    chart_type = spec.get("type")
+    if chart_type not in valid_types:
+        raise streamlit.errors.StreamlitAPIException(
+            f"Invalid chart type '{chart_type}'. Valid types: {', '.join(sorted(valid_types))}"
+        )
+
+    if "data" not in spec:
+        raise streamlit.errors.StreamlitAPIException("spec must contain a 'data' field with labels and datasets")
+
+    component = _get_component()
+    component(
+        key=key,
+        data={
+            "spec": spec,
+            "height": height,
+            "theme": theme,
+        },
+        default=None,
+    )
+
+
+def example_bar_chart() -> None:
+    """Basic bar chart example."""
+    st.write("### Bar Chart")
+    spec = {
+        "type": "bar",
+        "data": {
+            "labels": ["January", "February", "March", "April", "May"],
+            "datasets": [{"label": "Sales", "data": [65, 59, 80, 81, 56]}],
+        },
+    }
+    chartjs_chart(spec)
+
+
+def example_line_chart() -> None:
+    """Multi-dataset line chart example."""
+    st.write("### Line Chart")
+    spec = {
+        "type": "line",
+        "data": {
+            "labels": ["Q1", "Q2", "Q3", "Q4"],
+            "datasets": [
+                {"label": "2024", "data": [10, 20, 15, 25]},
+                {"label": "2025", "data": [15, 25, 20, 30]},
+            ],
+        },
+        "options": {
+            "plugins": {"title": {"display": True, "text": "Quarterly Revenue"}},
+        },
+    }
+    chartjs_chart(spec)
+
+
+def example_pie_chart() -> None:
+    """Pie chart example."""
+    st.write("### Pie Chart")
+    spec = {
+        "type": "pie",
+        "data": {
+            "labels": ["Red", "Blue", "Yellow", "Green"],
+            "datasets": [{"data": [30, 25, 20, 25]}],
+        },
+    }
+    chartjs_chart(spec)
+
+
+def example_radar_chart() -> None:
+    """Radar chart comparing multiple datasets."""
+    st.write("### Radar Chart")
+    spec = {
+        "type": "radar",
+        "data": {
+            "labels": ["Speed", "Reliability", "Comfort", "Safety", "Efficiency"],
+            "datasets": [
+                {"label": "Car A", "data": [65, 59, 90, 81, 56]},
+                {"label": "Car B", "data": [28, 48, 40, 19, 96]},
+            ],
+        },
+    }
+    chartjs_chart(spec)
+
+
+def example_doughnut_chart() -> None:
+    """Doughnut chart example."""
+    st.write("### Doughnut Chart")
+    spec = {
+        "type": "doughnut",
+        "data": {
+            "labels": ["Desktop", "Mobile", "Tablet"],
+            "datasets": [{"data": [55, 35, 10]}],
+        },
+        "options": {
+            "plugins": {"title": {"display": True, "text": "Traffic by Device"}},
+        },
+    }
+    chartjs_chart(spec)
+
+
+__title__ = "Chart.js Chart"
+__desc__ = "Display charts using the Chart.js library with Streamlit theme integration."
+__icon__ = "📊"
+__examples__ = [
+    example_bar_chart,
+    example_line_chart,
+    example_pie_chart,
+    example_radar_chart,
+    example_doughnut_chart,
+]
+__author__ = "Lukas Masuch"
+__created_at__ = date(2026, 4, 14)

--- a/src/streamlit_extras/chartjs_chart/frontend/package.json
+++ b/src/streamlit_extras/chartjs_chart/frontend/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "chartjs_chart",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "npm run clean && npm run typecheck && npm run build:frontend:production",
+    "build:frontend:production": "cross-env NODE_ENV=production vite build",
+    "clean": "rimraf build",
+    "dev": "cross-env NODE_ENV=development vite build --watch",
+    "format": "prettier --write src/**/*.{ts,tsx} vite.config.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not ie <= 11",
+    "not op_mini all"
+  ],
+  "prettier": {},
+  "dependencies": {
+    "@streamlit/component-v2-lib": "^0.2.0",
+    "chart.js": "^4.4.9",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "@types/react": "^18.3.20",
+    "@types/react-dom": "^18.3.6",
+    "@vitejs/plugin-react": "^5.1.0",
+    "cross-env": "^10.1.0",
+    "prettier": "^3.6.2",
+    "rimraf": "^6.1.0",
+    "typescript": "^5.8.3",
+    "vite": "^7.1.12"
+  }
+}

--- a/src/streamlit_extras/chartjs_chart/frontend/src/ChartJSChart.tsx
+++ b/src/streamlit_extras/chartjs_chart/frontend/src/ChartJSChart.tsx
@@ -1,0 +1,419 @@
+import { Chart, ChartConfiguration, registerables } from "chart.js";
+import { useEffect, useRef, useState, useCallback } from "react";
+
+// Register all Chart.js components
+Chart.register(...registerables);
+
+// Use a looser type for the spec to handle dynamic theming
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ChartSpec = Record<string, any>;
+
+export interface ChartJSChartDataShape {
+  spec: ChartSpec;
+  height: "content" | "stretch" | number;
+  theme: "streamlit" | null;
+}
+
+interface ChartJSChartProps {
+  spec: ChartSpec;
+  height: "content" | "stretch" | number;
+  theme: "streamlit" | null;
+}
+
+// Fallback colors if CSS variables aren't available
+const FALLBACK_COLORS = [
+  "#FF4B4B",
+  "#1C83E1",
+  "#00C4B4",
+  "#FA8C16",
+  "#9254DE",
+  "#F5222D",
+  "#52C41A",
+  "#FAAD14",
+  "#13C2C2",
+  "#EB2F96",
+];
+
+type ThemeColors = {
+  textColor: string;
+  backgroundColor: string;
+  borderColor: string;
+  fontFamily: string;
+  chartColors: string[];
+};
+
+// Helper to get CSS variable from the correct element (Shadow DOM aware)
+const getCSSVariable = (
+  element: HTMLElement | null,
+  name: string,
+  fallback: string,
+): string => {
+  if (!element) return fallback;
+
+  // In Shadow DOM, get computed style from the host element
+  const host = (element.getRootNode() as ShadowRoot)?.host ?? element;
+  const value = getComputedStyle(host as Element)
+    .getPropertyValue(name)
+    .trim();
+  return value || fallback;
+};
+
+// Get chart colors from Streamlit's CSS variable
+const getChartColors = (element: HTMLElement | null): string[] => {
+  const raw = getCSSVariable(element, "--st-chart-categorical-colors", "");
+  if (raw) {
+    // Split comma-separated colors and trim whitespace
+    return raw.split(",").map((c) => c.trim());
+  }
+  return FALLBACK_COLORS;
+};
+
+// Read all theme colors from CSS variables
+const getThemeColors = (element: HTMLElement | null): ThemeColors => {
+  return {
+    textColor: getCSSVariable(element, "--st-text-color", "#31333F"),
+    backgroundColor: getCSSVariable(element, "--st-background-color", "#FFFFFF"),
+    borderColor: getCSSVariable(
+      element,
+      "--st-border-color-light",
+      "rgba(128, 128, 128, 0.2)",
+    ),
+    fontFamily: getCSSVariable(
+      element,
+      "--st-font",
+      '"Source Sans Pro", sans-serif',
+    ),
+    chartColors: getChartColors(element),
+  };
+};
+
+// Apply Streamlit theme to Chart.js configuration
+const applyStreamlitTheme = (
+  spec: ChartSpec,
+  colors: ThemeColors,
+): ChartSpec => {
+  // Deep clone the spec to avoid mutating the original
+  const themedSpec = JSON.parse(JSON.stringify(spec)) as ChartSpec;
+
+  const { textColor, backgroundColor, borderColor, fontFamily, chartColors } =
+    colors;
+
+  // Apply colors to datasets if not already specified
+  if (themedSpec.data?.datasets) {
+    themedSpec.data.datasets = themedSpec.data.datasets.map(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (dataset: any, idx: number) => {
+        const color = chartColors[idx % chartColors.length];
+
+        // For pie/doughnut/polarArea, use array of colors for segments
+        const isPieType = ["pie", "doughnut", "polarArea"].includes(
+          themedSpec.type as string,
+        );
+
+        if (isPieType) {
+          const dataLength =
+            (dataset.data as unknown[])?.length || chartColors.length;
+          return {
+            ...dataset,
+            backgroundColor:
+              dataset.backgroundColor || chartColors.slice(0, dataLength),
+            borderColor: dataset.borderColor || backgroundColor,
+            borderWidth: dataset.borderWidth ?? 2,
+          };
+        }
+
+        // For line/radar charts, use transparent background with solid border
+        const isLineType = ["line", "radar"].includes(
+          themedSpec.type as string,
+        );
+
+        if (isLineType) {
+          return {
+            ...dataset,
+            borderColor: dataset.borderColor || color,
+            backgroundColor: dataset.backgroundColor || `${color}33`, // 20% opacity
+            pointBackgroundColor: dataset.pointBackgroundColor || color,
+            pointBorderColor: dataset.pointBorderColor || backgroundColor,
+            tension: dataset.tension ?? 0.4, // Smooth curves by default
+          };
+        }
+
+        // For bar/bubble/scatter charts
+        return {
+          ...dataset,
+          backgroundColor: dataset.backgroundColor || `${color}CC`, // 80% opacity
+          borderColor: dataset.borderColor || color,
+          borderWidth: dataset.borderWidth ?? 1,
+        };
+      },
+    );
+  }
+
+  // Apply theme to options
+  themedSpec.options = themedSpec.options || {};
+
+  // Configure plugins
+  themedSpec.options.plugins = themedSpec.options.plugins || {};
+
+  // Legend styling
+  themedSpec.options.plugins.legend = {
+    labels: {
+      color: textColor,
+      font: {
+        family: fontFamily,
+      },
+    },
+    ...themedSpec.options.plugins.legend,
+  };
+
+  // Title styling
+  if (themedSpec.options.plugins.title) {
+    themedSpec.options.plugins.title = {
+      color: textColor,
+      font: {
+        family: fontFamily,
+        size: 14,
+        weight: "bold" as const,
+      },
+      ...themedSpec.options.plugins.title,
+    };
+  }
+
+  // Tooltip styling
+  themedSpec.options.plugins.tooltip = {
+    backgroundColor: backgroundColor,
+    titleColor: textColor,
+    bodyColor: textColor,
+    borderColor: borderColor,
+    borderWidth: 1,
+    cornerRadius: 4,
+    ...themedSpec.options.plugins.tooltip,
+  };
+
+  // Scale styling (for charts with axes)
+  const hasScales = !["pie", "doughnut", "polarArea", "radar"].includes(
+    themedSpec.type as string,
+  );
+
+  if (hasScales) {
+    themedSpec.options.scales = themedSpec.options.scales || {};
+
+    // X axis
+    themedSpec.options.scales.x = {
+      ticks: {
+        color: textColor,
+        font: {
+          family: fontFamily,
+        },
+      },
+      grid: {
+        color: borderColor,
+      },
+      ...themedSpec.options.scales.x,
+    };
+
+    // Y axis
+    themedSpec.options.scales.y = {
+      ticks: {
+        color: textColor,
+        font: {
+          family: fontFamily,
+        },
+      },
+      grid: {
+        color: borderColor,
+      },
+      ...themedSpec.options.scales.y,
+    };
+  }
+
+  // Radar chart scale styling
+  if (themedSpec.type === "radar") {
+    themedSpec.options.scales = themedSpec.options.scales || {};
+    themedSpec.options.scales.r = {
+      ticks: {
+        color: textColor,
+        backdropColor: "transparent",
+      },
+      pointLabels: {
+        color: textColor,
+      },
+      grid: {
+        color: borderColor,
+      },
+      angleLines: {
+        color: borderColor,
+      },
+      ...themedSpec.options.scales.r,
+    };
+  }
+
+  // Polar area chart scale styling
+  if (themedSpec.type === "polarArea") {
+    themedSpec.options.scales = themedSpec.options.scales || {};
+    themedSpec.options.scales.r = {
+      ticks: {
+        color: textColor,
+        backdropColor: "transparent",
+      },
+      grid: {
+        color: borderColor,
+      },
+      ...themedSpec.options.scales.r,
+    };
+  }
+
+  return themedSpec;
+};
+
+const ChartJSChart: React.FC<ChartJSChartProps> = ({ spec, height, theme }) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const chartRef = useRef<Chart | null>(null);
+  const [containerHeight, setContainerHeight] = useState<string | number>(
+    "auto",
+  );
+
+  // Track theme colors with polling (like json_editor and sigma_graph)
+  const [themeColors, setThemeColors] = useState<ThemeColors>(() => ({
+    textColor: "#31333F",
+    backgroundColor: "#FFFFFF",
+    borderColor: "rgba(128, 128, 128, 0.2)",
+    fontFamily: '"Source Sans Pro", sans-serif',
+    chartColors: FALLBACK_COLORS,
+  }));
+  const lastThemeHash = useRef<string>("");
+
+  // Poll for CSS variable changes (MutationObserver doesn't catch CSS custom property changes)
+  useEffect(() => {
+    if (theme !== "streamlit") return;
+    if (!containerRef.current) return;
+
+    const updateThemeFromCssVars = () => {
+      const colors = getThemeColors(containerRef.current);
+
+      // Only update if colors actually changed (avoid unnecessary re-renders)
+      const hash = JSON.stringify(colors);
+      if (hash !== lastThemeHash.current) {
+        lastThemeHash.current = hash;
+        setThemeColors(colors);
+      }
+    };
+
+    // Initial detection
+    updateThemeFromCssVars();
+
+    // Poll for changes every 100ms
+    const intervalId = setInterval(updateThemeFromCssVars, 100);
+
+    return () => clearInterval(intervalId);
+  }, [theme]);
+
+  // Memoize the theming function
+  const getThemedSpec = useCallback(() => {
+    if (theme === "streamlit") {
+      return applyStreamlitTheme(spec, themeColors);
+    }
+    return spec;
+  }, [spec, theme, themeColors]);
+
+  // Calculate container height based on height prop
+  useEffect(() => {
+    if (typeof height === "number") {
+      setContainerHeight(height);
+    } else if (height === "stretch") {
+      setContainerHeight("100%");
+    } else {
+      // "content" - let Chart.js determine height
+      setContainerHeight("auto");
+    }
+  }, [height]);
+
+  // Create/update the chart
+  useEffect(() => {
+    if (!canvasRef.current) return;
+
+    const ctx = canvasRef.current.getContext("2d");
+    if (!ctx) return;
+
+    // Destroy existing chart if it exists
+    if (chartRef.current) {
+      chartRef.current.destroy();
+      chartRef.current = null;
+    }
+
+    // Get themed spec
+    const themedSpec = getThemedSpec();
+
+    // Determine default aspect ratio based on chart type
+    // Circular charts (pie, doughnut, radar, polarArea) look best square
+    // Bar/line/scatter charts look best wider
+    const chartType = themedSpec.type as string;
+    const isCircularChart = ["pie", "doughnut", "radar", "polarArea"].includes(
+      chartType,
+    );
+    const defaultAspectRatio = isCircularChart ? 1.5 : 2;
+
+    // Configure Chart.js defaults for responsive behavior
+    const chartConfig = {
+      ...themedSpec,
+      options: {
+        ...themedSpec.options,
+        responsive: true,
+        maintainAspectRatio: height === "content",
+        // Use chart-type-appropriate aspect ratio, allow user override
+        aspectRatio: themedSpec.options?.aspectRatio ?? defaultAspectRatio,
+      },
+    } as ChartConfiguration;
+
+    // Create new chart
+    chartRef.current = new Chart(ctx, chartConfig);
+
+    // Cleanup function
+    return () => {
+      if (chartRef.current) {
+        chartRef.current.destroy();
+        chartRef.current = null;
+      }
+    };
+  }, [getThemedSpec, height]);
+
+  // Handle resize with ResizeObserver
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const resizeObserver = new ResizeObserver(() => {
+      // Chart.js needs explicit resize call when container grows
+      if (chartRef.current) {
+        chartRef.current.resize();
+      }
+    });
+
+    resizeObserver.observe(container);
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, []);
+
+  const containerStyle: React.CSSProperties = {
+    width: "100%",
+    height: containerHeight,
+    minHeight: height === "stretch" ? "200px" : undefined,
+    position: "relative",
+  };
+
+  const canvasStyle: React.CSSProperties = {
+    width: "100%",
+    height: "100%",
+  };
+
+  return (
+    <div ref={containerRef} style={containerStyle}>
+      <canvas ref={canvasRef} style={canvasStyle} />
+    </div>
+  );
+};
+
+export default ChartJSChart;

--- a/src/streamlit_extras/chartjs_chart/frontend/src/index.tsx
+++ b/src/streamlit_extras/chartjs_chart/frontend/src/index.tsx
@@ -1,0 +1,65 @@
+import {
+  FrontendRenderer,
+  FrontendRendererArgs,
+} from "@streamlit/component-v2-lib";
+import { StrictMode } from "react";
+import { createRoot, Root } from "react-dom/client";
+
+import ChartJSChart, { ChartJSChartDataShape } from "./ChartJSChart";
+
+// Handle the possibility of multiple instances of the component to keep track
+// of the React roots for each component instance.
+const reactRoots: WeakMap<FrontendRendererArgs["parentElement"], Root> =
+  new WeakMap();
+
+// This component is display-only, so we use an empty state shape
+type ChartJSStateShape = Record<string, never>;
+
+const ChartJSChartRoot: FrontendRenderer<
+  ChartJSStateShape,
+  ChartJSChartDataShape
+> = (args) => {
+  const { data, parentElement } = args;
+
+  // Get the react-root div from the parentElement that we defined in our
+  // `st.components.v2.component` call in Python.
+  const rootElement = parentElement.querySelector(".react-root");
+
+  if (!rootElement) {
+    throw new Error("Unexpected: React root element not found");
+  }
+
+  // Check to see if we already have a React root for this component instance.
+  let reactRoot = reactRoots.get(parentElement);
+  if (!reactRoot) {
+    // If we don't, create a new root for the React application using the React
+    // DOM API.
+    // @see https://react.dev/reference/react-dom/client/createRoot
+    reactRoot = createRoot(rootElement);
+    reactRoots.set(parentElement, reactRoot);
+  }
+
+  // Extract data passed from Streamlit on the Python side.
+  const { spec, height, theme } = data;
+
+  // Render/re-render the React application into the root using the React DOM
+  // API.
+  reactRoot.render(
+    <StrictMode>
+      <ChartJSChart spec={spec} height={height} theme={theme} />
+    </StrictMode>,
+  );
+
+  // Return a function to cleanup the React application in the Streamlit
+  // component lifecycle.
+  return () => {
+    const reactRoot = reactRoots.get(parentElement);
+
+    if (reactRoot) {
+      reactRoot.unmount();
+      reactRoots.delete(parentElement);
+    }
+  };
+};
+
+export default ChartJSChartRoot;

--- a/src/streamlit_extras/chartjs_chart/frontend/tsconfig.json
+++ b/src/streamlit_extras/chartjs_chart/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/src/streamlit_extras/chartjs_chart/frontend/vite.config.ts
+++ b/src/streamlit_extras/chartjs_chart/frontend/vite.config.ts
@@ -1,0 +1,42 @@
+import react from "@vitejs/plugin-react";
+import process from "node:process";
+import { defineConfig, UserConfig } from "vite";
+
+/**
+ * Vite configuration for Streamlit Custom Component v2 development using React.
+ *
+ * @see https://vitejs.dev/config/ for complete Vite configuration options.
+ */
+export default defineConfig(() => {
+  const isProd = process.env.NODE_ENV === "production";
+  const isDev = !isProd;
+
+  return {
+    base: "./",
+    plugins: [react()],
+    define: {
+      // We are building in library mode, we need to define the NODE_ENV
+      // variable to prevent issues when executing the JS.
+      "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV),
+    },
+    build: {
+      minify: isDev ? false : "esbuild",
+      outDir: "build",
+      sourcemap: isDev,
+      lib: {
+        entry: "./src/index.tsx",
+        name: "ChartJSChart",
+        formats: ["es"],
+        fileName: "index-[hash]",
+      },
+      ...(!isDev && {
+        esbuild: {
+          drop: ["console", "debugger"],
+          minifyIdentifiers: true,
+          minifySyntax: true,
+          minifyWhitespace: true,
+        },
+      }),
+    },
+  } satisfies UserConfig;
+});

--- a/src/streamlit_extras/pyproject.toml
+++ b/src/streamlit_extras/pyproject.toml
@@ -6,6 +6,9 @@ name = "streamlit-extras"
 version = "0.0.1"
 
 [[tool.streamlit.component.components]]
+name = "chartjs_chart"
+asset_dir = "chartjs_chart/frontend/build"
+[[tool.streamlit.component.components]]
 name = "image_compare_slider"
 asset_dir = "image_compare_slider/frontend/build"
 [[tool.streamlit.component.components]]


### PR DESCRIPTION
## Summary

<img width="654" height="489" alt="image" src="https://github.com/user-attachments/assets/08ab344e-b92c-4f39-b897-7801667aed8c" />


- Adds new `chartjs_chart` extra for rendering charts using the Chart.js library
- Supports all Chart.js chart types: bar, line, pie, doughnut, radar, polarArea, bubble, scatter
- Integrates with Streamlit theming (uses `--st-chart-categorical-colors` and other CSS variables)
- Dynamic theme switching when toggling light/dark mode
- Responsive resizing with chart-type-appropriate default aspect ratios

## Test plan

- [ ] Run gallery demo to verify all chart examples render correctly
- [ ] Toggle between light/dark mode to verify theme updates dynamically
- [ ] Resize browser window to verify charts resize properly in both directions