### PR TITLE
Add `image_crop` extra for interactive image cropping

### DIFF
--- a/src/streamlit_extras/AGENTS.md
+++ b/src/streamlit_extras/AGENTS.md
@@ -58,6 +58,7 @@ Use this guide to select the appropriate implementation approach:
 | `great_tables` | Render Great Tables objects in Streamlit | st.html |
 | `grid` | Place elements on a specified grid layout | pure python |
 | `image_compare_slider` | Compare two images with an interactive slider overlay | components v2: react |
+| `image_crop` | Interactive image cropping with adjustable bounds | components v2: react |
 | `image_selector` | Select images from a gallery | pure python |
 | `json_editor` | Interactive JSON viewer/editor built with React | components v2: react |
 | `jupyterlite` | Add a Jupyterlite sandbox to your app | components v1: iframe |

--- a/src/streamlit_extras/image_crop/__init__.py
+++ b/src/streamlit_extras/image_crop/__init__.py
@@ -162,8 +162,36 @@ def image_crop(
             if field not in initial_crop:
                 raise StreamlitAPIException(f"initial_crop must contain '{field}' key.")
             value = initial_crop[field]
-            if not isinstance(value, (int, float)):
+            # Reject bools (which are technically ints in Python)
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
                 raise StreamlitAPIException(f"initial_crop['{field}'] must be a number, got {type(value).__name__}.")
+
+        # Validate ranges (0-1 normalized values)
+        x = initial_crop["x"]
+        y = initial_crop["y"]
+        crop_width = initial_crop["width"]
+        crop_height = initial_crop["height"]
+
+        if not 0 <= x <= 1:
+            raise StreamlitAPIException(f"initial_crop['x'] must be between 0 and 1, got {x}.")
+        if not 0 <= y <= 1:
+            raise StreamlitAPIException(f"initial_crop['y'] must be between 0 and 1, got {y}.")
+        if not 0 < crop_width <= 1:
+            raise StreamlitAPIException(
+                f"initial_crop['width'] must be greater than 0 and at most 1, got {crop_width}."
+            )
+        if not 0 < crop_height <= 1:
+            raise StreamlitAPIException(
+                f"initial_crop['height'] must be greater than 0 and at most 1, got {crop_height}."
+            )
+        if x + crop_width > 1:
+            raise StreamlitAPIException(
+                f"initial_crop['x'] + initial_crop['width'] must be at most 1, got {x + crop_width}."
+            )
+        if y + crop_height > 1:
+            raise StreamlitAPIException(
+                f"initial_crop['y'] + initial_crop['height'] must be at most 1, got {y + crop_height}."
+            )
 
     # Validate height
     if isinstance(height, int) and height < 1:
@@ -237,12 +265,20 @@ def image_crop(
     if current_crop is None:
         return None
 
+    # Helper to safely get and normalize a crop value
+    def get_normalized(key: str) -> float:
+        value = current_crop.get(key)
+        if value is None or not isinstance(value, (int, float)):
+            return 0.0
+        # Convert from 0-100 (frontend) to 0-1 (API) and clamp
+        return max(0.0, min(1.0, float(value) / 100))
+
     # Convert from 0-100 (frontend) to 0-1 (API) and return as CropBounds
     return CropBounds(
-        x=current_crop.get("x", 0) / 100,
-        y=current_crop.get("y", 0) / 100,
-        width=current_crop.get("width", 0) / 100,
-        height=current_crop.get("height", 0) / 100,
+        x=get_normalized("x"),
+        y=get_normalized("y"),
+        width=get_normalized("width"),
+        height=get_normalized("height"),
     )
 
 

--- a/src/streamlit_extras/image_crop/__init__.py
+++ b/src/streamlit_extras/image_crop/__init__.py
@@ -1,0 +1,322 @@
+"""Interactive image cropping component for Streamlit.
+
+A component that allows users to select a rectangular crop region on an image,
+returning the bounds as percentages. Commonly used for photo editing, avatar
+selection, and annotation workflows.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from functools import cache
+from typing import TYPE_CHECKING, Any, Literal, TypedDict
+from uuid import uuid4
+
+import streamlit as st
+import streamlit.components.v2
+from streamlit.elements.lib.image_utils import image_to_url
+from streamlit.elements.lib.layout_utils import LayoutConfig
+from streamlit.errors import StreamlitAPIException
+
+from streamlit_extras import extra
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from io import BytesIO
+    from pathlib import Path
+
+    import numpy.typing as npt
+    from PIL import Image
+
+    ImageLike = str | bytes | BytesIO | Path | Image.Image | npt.NDArray[Any]
+
+
+class CropBounds(TypedDict):
+    """Crop bounds as normalized values (0-1)."""
+
+    x: float
+    y: float
+    width: float
+    height: float
+
+
+def _on_crop_change() -> None:
+    """Callback function for when the crop region changes."""
+
+
+@cache
+def _get_component() -> Any:
+    """Lazily initialize the CCv2 component.
+
+    Returns:
+        The component callable.
+    """
+    return streamlit.components.v2.component(
+        "streamlit-extras.image_crop",
+        js="index-*.js",
+        html='<div class="react-root"></div>',
+    )
+
+
+def _convert_image_to_url(image: ImageLike) -> str:
+    """Convert an image to a URL that can be served by Streamlit.
+
+    Returns:
+        A URL string that Streamlit can serve.
+    """
+    image_id = str(uuid4())
+    return image_to_url(
+        image,
+        layout_config=LayoutConfig(width="content"),
+        clamp=False,
+        channels="RGB",
+        output_format="auto",
+        image_id=image_id,
+    )
+
+
+@extra
+def image_crop(
+    image: ImageLike,
+    *,
+    aspect: float | None = None,
+    min_width: int = 10,
+    min_height: int = 10,
+    initial_crop: CropBounds | None = None,
+    circular: bool = False,
+    rule_of_thirds: bool = False,
+    height: Literal["content"] | int = "content",
+    width: Literal["stretch", "content"] | int = "stretch",
+    on_change: Literal["ignore", "rerun"] | Callable[[], None] = "rerun",
+    key: str | None = None,
+) -> CropBounds | None:
+    """Display an interactive image cropping component.
+
+    Allows users to select a rectangular region on an image by clicking and
+    dragging. Returns the crop bounds as normalized values (0-1).
+
+    Args:
+        image: The image to crop. Supports URLs (str), file paths (str or Path),
+            PIL images, numpy arrays, or raw bytes/BytesIO.
+        aspect: Fixed aspect ratio for the crop selection (e.g., 1 for square,
+            16/9 for landscape). None allows free-form selection.
+        min_width: Minimum crop width in pixels. Default is 10.
+        min_height: Minimum crop height in pixels. Default is 10.
+        initial_crop: Initial crop selection as a CropBounds dict with x, y,
+            width, and height as normalized values (0-1). None shows no initial
+            selection.
+        circular: If True, displays a circular mask over the selection. The
+            returned bounds are still rectangular. Default is False.
+        rule_of_thirds: If True, displays composition guideline grid.
+            Default is False.
+        height: Component height. "content" (default) auto-sizes based on image
+            aspect ratio. Integer sets fixed pixel height.
+        width: Component width. "stretch" (default) fills container width.
+            "content" sizes to fit content. Integer sets fixed pixel width.
+        on_change: Controls behavior when the crop region changes.
+            "rerun" (default): Triggers a script rerun, returns the crop bounds.
+            "ignore": No rerun, always returns None.
+            Callable: Calls the provided callback, returns the crop bounds.
+        key: Unique key for this component instance.
+
+    Returns:
+        CropBounds dict with x, y, width, and height as normalized values (0-1)
+        when a selection exists and on_change is not "ignore". Returns None
+        when no selection is active or on_change is "ignore".
+
+    Raises:
+        StreamlitAPIException: If parameters are invalid.
+
+    Example:
+        Basic cropping:
+
+        ```python
+        crop = image_crop("photo.jpg")
+        if crop:
+            st.write(f"Selected: {crop}")
+        ```
+
+        Square avatar selection:
+
+        ```python
+        crop = image_crop(
+            image,
+            aspect=1,
+            circular=True,
+        )
+        ```
+    """
+    # Validate aspect
+    if aspect is not None and aspect <= 0:
+        raise StreamlitAPIException(f"aspect must be positive, got {aspect}.")
+
+    # Validate min dimensions
+    if min_width < 1:
+        raise StreamlitAPIException(f"min_width must be at least 1, got {min_width}.")
+    if min_height < 1:
+        raise StreamlitAPIException(f"min_height must be at least 1, got {min_height}.")
+
+    # Validate initial_crop
+    if initial_crop is not None:
+        for field in ("x", "y", "width", "height"):
+            if field not in initial_crop:
+                raise StreamlitAPIException(f"initial_crop must contain '{field}' key.")
+            value = initial_crop[field]
+            if not isinstance(value, (int, float)):
+                raise StreamlitAPIException(f"initial_crop['{field}'] must be a number, got {type(value).__name__}.")
+
+    # Validate height
+    if isinstance(height, int) and height < 1:
+        raise StreamlitAPIException(f"height must be at least 1 pixel, got {height}.")
+    if not isinstance(height, int) and height != "content":
+        raise StreamlitAPIException(f"height must be 'content' or an integer, got {height!r}.")
+
+    # Validate width
+    if isinstance(width, int) and width < 1:
+        raise StreamlitAPIException(f"width must be at least 1 pixel, got {width}.")
+    if not isinstance(width, int) and width not in ("stretch", "content"):
+        raise StreamlitAPIException(f"width must be 'stretch', 'content', or an integer, got {width!r}.")
+
+    # Validate on_change parameter
+    if on_change not in ("ignore", "rerun") and not callable(on_change):
+        raise StreamlitAPIException(f"on_change must be 'ignore', 'rerun', or a callable, got {on_change!r}.")
+
+    # Convert image to URL
+    image_url = _convert_image_to_url(image)
+
+    # Prepare initial crop for frontend (convert 0-1 to 0-100 for react-image-crop)
+    frontend_initial_crop = None
+    if initial_crop is not None:
+        frontend_initial_crop = {
+            "x": max(0, min(100, initial_crop["x"] * 100)),
+            "y": max(0, min(100, initial_crop["y"] * 100)),
+            "width": max(0, min(100, initial_crop["width"] * 100)),
+            "height": max(0, min(100, initial_crop["height"] * 100)),
+        }
+
+    # Determine if we should track crop changes
+    track_crop = on_change != "ignore"
+
+    # Build component kwargs
+    component_kwargs: dict[str, Any] = {
+        "key": key,
+        "data": {
+            "image_url": image_url,
+            "aspect": aspect,
+            "min_width": min_width,
+            "min_height": min_height,
+            "initial_crop": frontend_initial_crop,
+            "circular": circular,
+            "rule_of_thirds": rule_of_thirds,
+            "height": height,
+            "width": width,
+            "track_crop": track_crop,
+        },
+        "height": height,
+        "width": width,
+    }
+
+    # Only add callback and default if tracking crop
+    if track_crop:
+        component_kwargs["default"] = {"crop": frontend_initial_crop}
+        if callable(on_change):
+            component_kwargs["on_crop_change"] = on_change
+        else:  # on_change == "rerun"
+            component_kwargs["on_crop_change"] = _on_crop_change
+
+    component = _get_component()
+    result = component(**component_kwargs)
+
+    # Return None when ignoring changes
+    if on_change == "ignore":
+        return None
+
+    # Get the current crop from the result
+    current_crop = result.get("crop")
+
+    if current_crop is None:
+        return None
+
+    # Convert from 0-100 (frontend) to 0-1 (API) and return as CropBounds
+    return CropBounds(
+        x=current_crop.get("x", 0) / 100,
+        y=current_crop.get("y", 0) / 100,
+        width=current_crop.get("width", 0) / 100,
+        height=current_crop.get("height", 0) / 100,
+    )
+
+
+def example_basic() -> None:
+    """Basic image cropping."""
+    st.write("### Basic Cropping")
+    st.write("Click and drag on the image to select a crop region.")
+
+    crop = image_crop(
+        "https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800",
+        key="basic_crop",
+    )
+    if crop:
+        st.write(
+            f"**Selected region:** x={crop['x']:.2f}, y={crop['y']:.2f}, "
+            f"width={crop['width']:.2f}, height={crop['height']:.2f}"
+        )
+    else:
+        st.write("No region selected yet.")
+
+
+def example_square() -> None:
+    """Square aspect ratio cropping."""
+    st.write("### Square Crop")
+    st.write("Fixed 1:1 aspect ratio for avatar-style selection.")
+
+    crop = image_crop(
+        "https://images.unsplash.com/photo-1682687220742-aba13b6e50ba?w=600",
+        aspect=1,
+        initial_crop={"x": 0.25, "y": 0.1, "width": 0.5, "height": 0.5},
+        key="square_crop",
+    )
+    if crop:
+        st.write(f"**Crop bounds:** {crop}")
+
+
+def example_circular() -> None:
+    """Circular crop mask."""
+    st.write("### Circular Mask")
+    st.write("Circular display for profile picture selection.")
+
+    crop = image_crop(
+        "https://images.unsplash.com/photo-1469474968028-56623f02e42e?w=800",
+        aspect=1,
+        circular=True,
+        key="circular_crop",
+    )
+    if crop:
+        st.write(f"**Crop bounds:** {crop}")
+
+
+def example_composition() -> None:
+    """Composition helper with rule of thirds."""
+    st.write("### Composition Helper")
+    st.write("Rule of thirds grid for photo composition.")
+
+    crop = image_crop(
+        "https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800",
+        aspect=16 / 9,
+        rule_of_thirds=True,
+        key="composition_crop",
+    )
+    if crop:
+        st.write(f"**16:9 crop:** {crop}")
+
+
+__title__ = "Image Crop"
+__desc__ = "Interactive image cropping with adjustable bounds."
+__icon__ = "✂️"
+__examples__ = [
+    example_basic,
+    example_square,
+    example_circular,
+    example_composition,
+]
+__author__ = "Lukas Masuch"
+__created_at__ = date(2026, 4, 14)

--- a/src/streamlit_extras/image_crop/frontend/package.json
+++ b/src/streamlit_extras/image_crop/frontend/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "image-crop",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "npm run clean && npm run typecheck && npm run build:frontend:production",
+    "build:frontend:production": "cross-env NODE_ENV=production vite build",
+    "clean": "rimraf build",
+    "dev": "cross-env NODE_ENV=development vite build --watch",
+    "format": "prettier --write src/**/*.{ts,tsx} vite.config.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not ie <= 11",
+    "not op_mini all"
+  ],
+  "prettier": {},
+  "dependencies": {
+    "@streamlit/component-v2-lib": "^0.2.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-image-crop": "^11.0.7"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "@types/react": "^18.3.20",
+    "@types/react-dom": "^18.3.6",
+    "@vitejs/plugin-react": "^5.1.0",
+    "cross-env": "^10.1.0",
+    "prettier": "^3.6.2",
+    "rimraf": "^6.1.0",
+    "typescript": "^5.8.3",
+    "vite": "^7.1.12"
+  }
+}

--- a/src/streamlit_extras/image_crop/frontend/src/ImageCrop.tsx
+++ b/src/streamlit_extras/image_crop/frontend/src/ImageCrop.tsx
@@ -42,6 +42,8 @@ const CUSTOM_STYLES = `
 // Combined styles to render inline
 const ALL_STYLES = reactCropStyles + "\n" + CUSTOM_STYLES;
 
+// CropBounds in the frontend represents react-image-crop percent values (0-100).
+// Note: Python API uses normalized 0-1 values; conversion happens at the boundary.
 export type CropBounds = {
   x: number;
   y: number;
@@ -153,14 +155,23 @@ function cropBoundsToPercentCrop(bounds: CropBounds): PercentCrop {
 }
 
 /**
- * Convert react-image-crop's PercentCrop to CropBounds.
+ * Normalize a percent crop value to ensure it's a valid number in [0, 100].
+ */
+function normalizePercentValue(value: number | undefined): number {
+  const normalized =
+    typeof value === "number" && Number.isFinite(value) ? value : 0;
+  return Math.min(100, Math.max(0, normalized));
+}
+
+/**
+ * Convert react-image-crop's PercentCrop to CropBounds with normalization.
  */
 function percentCropToCropBounds(crop: PercentCrop): CropBounds {
   return {
-    x: crop.x,
-    y: crop.y,
-    width: crop.width,
-    height: crop.height,
+    x: normalizePercentValue(crop.x),
+    y: normalizePercentValue(crop.y),
+    width: normalizePercentValue(crop.width),
+    height: normalizePercentValue(crop.height),
   };
 }
 
@@ -335,6 +346,21 @@ const ImageCrop: FC<ImageCropProps> = ({
       }
 
       const cropBounds = percentCropToCropBounds(percentCrop);
+      const last = lastCommittedCropRef.current;
+
+      // Skip if crop hasn't changed or has zero dimensions
+      if (
+        cropBounds.width === 0 ||
+        cropBounds.height === 0 ||
+        (last &&
+          cropBounds.x === last.x &&
+          cropBounds.y === last.y &&
+          cropBounds.width === last.width &&
+          cropBounds.height === last.height)
+      ) {
+        return;
+      }
+
       lastCommittedCropRef.current = cropBounds;
       setStateValue("crop", cropBounds);
     },

--- a/src/streamlit_extras/image_crop/frontend/src/ImageCrop.tsx
+++ b/src/streamlit_extras/image_crop/frontend/src/ImageCrop.tsx
@@ -205,6 +205,9 @@ const ImageCrop: FC<ImageCropProps> = ({
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastCommittedCropRef = useRef<CropBounds | null>(initialCrop);
 
+  // Track image aspect ratio for crop adjustments
+  const [imageAspectRatio, setImageAspectRatio] = useState<number | null>(null);
+
   // Debounce delay in milliseconds
   const DEBOUNCE_DELAY = 150;
 
@@ -214,7 +217,21 @@ const ImageCrop: FC<ImageCropProps> = ({
     [imageUrl],
   );
 
-  // Sync crop when initialCrop or aspect changes, adjusting for aspect ratio if needed
+  // Load image to get its aspect ratio
+  useEffect(() => {
+    const img = new Image();
+    img.onload = () => {
+      if (img.width > 0 && img.height > 0) {
+        setImageAspectRatio(img.width / img.height);
+      }
+    };
+    img.src = resolvedImageUrl;
+    return () => {
+      img.onload = null;
+    };
+  }, [resolvedImageUrl]);
+
+  // Sync crop when initialCrop, aspect, or image dimensions change
   useEffect(() => {
     if (!initialCrop) {
       setCrop(undefined);
@@ -224,27 +241,31 @@ const ImageCrop: FC<ImageCropProps> = ({
 
     let cropToSet = cropBoundsToPercentCrop(initialCrop);
 
-    // If there's an aspect constraint, adjust the crop to match
-    if (aspect) {
+    // If there's an aspect constraint and we know the image dimensions, adjust the crop
+    if (aspect && imageAspectRatio) {
       const currentWidth = cropToSet.width ?? 0;
       const currentHeight = cropToSet.height ?? 0;
       const currentX = cropToSet.x ?? 0;
       const currentY = cropToSet.y ?? 0;
 
       if (currentWidth > 0 && currentHeight > 0) {
-        const currentAspect = currentWidth / currentHeight;
+        // In percent space, the aspect ratio that produces a visually correct
+        // crop is: desiredAspect / imageAspect
+        // For a square (aspect=1) on a 2:1 image, we need width%/height% = 0.5
+        const targetPercentAspect = aspect / imageAspectRatio;
+        const currentPercentAspect = currentWidth / currentHeight;
 
-        // Only adjust if aspect doesn't match
-        if (Math.abs(currentAspect - aspect) >= 0.01) {
+        // Only adjust if aspect doesn't match (with tolerance)
+        if (Math.abs(currentPercentAspect - targetPercentAspect) >= 0.01) {
           let newWidth = currentWidth;
           let newHeight = currentHeight;
 
-          if (currentAspect > aspect) {
+          if (currentPercentAspect > targetPercentAspect) {
             // Current crop is wider than target - reduce width
-            newWidth = currentHeight * aspect;
+            newWidth = currentHeight * targetPercentAspect;
           } else {
             // Current crop is taller than target - reduce height
-            newHeight = currentWidth / aspect;
+            newHeight = currentWidth / targetPercentAspect;
           }
 
           // Adjust position to keep the crop centered
@@ -284,7 +305,7 @@ const ImageCrop: FC<ImageCropProps> = ({
     if (trackCrop) {
       setStateValue("crop", cropBounds);
     }
-  }, [initialCrop, aspect, trackCrop, setStateValue]);
+  }, [initialCrop, aspect, imageAspectRatio, trackCrop, setStateValue]);
 
   // Cleanup for debounce timer on unmount
   useEffect(() => {

--- a/src/streamlit_extras/image_crop/frontend/src/ImageCrop.tsx
+++ b/src/streamlit_extras/image_crop/frontend/src/ImageCrop.tsx
@@ -225,6 +225,81 @@ const ImageCrop: FC<ImageCropProps> = ({
     }
   }, [initialCrop]);
 
+  // Adjust existing crop when aspect ratio changes
+  useEffect(() => {
+    setCrop((prevCrop) => {
+      if (!prevCrop || prevCrop.unit !== "%" || !aspect) {
+        // No existing crop or no aspect constraint - nothing to adjust
+        return prevCrop;
+      }
+
+      const currentWidth = prevCrop.width ?? 0;
+      const currentHeight = prevCrop.height ?? 0;
+      const currentX = prevCrop.x ?? 0;
+      const currentY = prevCrop.y ?? 0;
+
+      if (currentWidth === 0 || currentHeight === 0) {
+        return prevCrop;
+      }
+
+      // Calculate current aspect ratio (width/height in percent space)
+      // Note: aspect prop is width/height ratio
+      const currentAspect = currentWidth / currentHeight;
+
+      // If aspect is already close enough, don't adjust
+      if (Math.abs(currentAspect - aspect) < 0.01) {
+        return prevCrop;
+      }
+
+      // Adjust crop to match new aspect ratio, keeping center point
+      let newWidth = currentWidth;
+      let newHeight = currentHeight;
+
+      if (currentAspect > aspect) {
+        // Current crop is wider than target - reduce width
+        newWidth = currentHeight * aspect;
+      } else {
+        // Current crop is taller than target - reduce height
+        newHeight = currentWidth / aspect;
+      }
+
+      // Adjust position to keep the crop centered
+      const centerX = currentX + currentWidth / 2;
+      const centerY = currentY + currentHeight / 2;
+      let newX = centerX - newWidth / 2;
+      let newY = centerY - newHeight / 2;
+
+      // Clamp to image bounds (0-100%)
+      if (newX < 0) {
+        newX = 0;
+      } else if (newX + newWidth > 100) {
+        newX = 100 - newWidth;
+      }
+      if (newY < 0) {
+        newY = 0;
+      } else if (newY + newHeight > 100) {
+        newY = 100 - newHeight;
+      }
+
+      const adjustedCrop: PercentCrop = {
+        unit: "%",
+        x: newX,
+        y: newY,
+        width: newWidth,
+        height: newHeight,
+      };
+
+      // Update the committed crop ref and notify Streamlit
+      if (trackCrop) {
+        const cropBounds = percentCropToCropBounds(adjustedCrop);
+        lastCommittedCropRef.current = cropBounds;
+        setStateValue("crop", cropBounds);
+      }
+
+      return adjustedCrop;
+    });
+  }, [aspect, trackCrop, setStateValue]);
+
   // Cleanup for debounce timer on unmount
   useEffect(() => {
     return () => {

--- a/src/streamlit_extras/image_crop/frontend/src/ImageCrop.tsx
+++ b/src/streamlit_extras/image_crop/frontend/src/ImageCrop.tsx
@@ -214,91 +214,77 @@ const ImageCrop: FC<ImageCropProps> = ({
     [imageUrl],
   );
 
-  // Sync crop when initialCrop changes (e.g., when props change on rerun)
+  // Sync crop when initialCrop or aspect changes, adjusting for aspect ratio if needed
   useEffect(() => {
-    if (initialCrop) {
-      setCrop(cropBoundsToPercentCrop(initialCrop));
-      lastCommittedCropRef.current = initialCrop;
-    } else {
+    if (!initialCrop) {
       setCrop(undefined);
       lastCommittedCropRef.current = null;
+      return;
     }
-  }, [initialCrop]);
 
-  // Adjust existing crop when aspect ratio changes
-  useEffect(() => {
-    setCrop((prevCrop) => {
-      if (!prevCrop || prevCrop.unit !== "%" || !aspect) {
-        // No existing crop or no aspect constraint - nothing to adjust
-        return prevCrop;
+    let cropToSet = cropBoundsToPercentCrop(initialCrop);
+
+    // If there's an aspect constraint, adjust the crop to match
+    if (aspect) {
+      const currentWidth = cropToSet.width ?? 0;
+      const currentHeight = cropToSet.height ?? 0;
+      const currentX = cropToSet.x ?? 0;
+      const currentY = cropToSet.y ?? 0;
+
+      if (currentWidth > 0 && currentHeight > 0) {
+        const currentAspect = currentWidth / currentHeight;
+
+        // Only adjust if aspect doesn't match
+        if (Math.abs(currentAspect - aspect) >= 0.01) {
+          let newWidth = currentWidth;
+          let newHeight = currentHeight;
+
+          if (currentAspect > aspect) {
+            // Current crop is wider than target - reduce width
+            newWidth = currentHeight * aspect;
+          } else {
+            // Current crop is taller than target - reduce height
+            newHeight = currentWidth / aspect;
+          }
+
+          // Adjust position to keep the crop centered
+          const centerX = currentX + currentWidth / 2;
+          const centerY = currentY + currentHeight / 2;
+          let newX = centerX - newWidth / 2;
+          let newY = centerY - newHeight / 2;
+
+          // Clamp to image bounds (0-100%)
+          if (newX < 0) {
+            newX = 0;
+          } else if (newX + newWidth > 100) {
+            newX = 100 - newWidth;
+          }
+          if (newY < 0) {
+            newY = 0;
+          } else if (newY + newHeight > 100) {
+            newY = 100 - newHeight;
+          }
+
+          cropToSet = {
+            unit: "%",
+            x: newX,
+            y: newY,
+            width: newWidth,
+            height: newHeight,
+          };
+        }
       }
+    }
 
-      const currentWidth = prevCrop.width ?? 0;
-      const currentHeight = prevCrop.height ?? 0;
-      const currentX = prevCrop.x ?? 0;
-      const currentY = prevCrop.y ?? 0;
+    setCrop(cropToSet);
+    const cropBounds = percentCropToCropBounds(cropToSet);
+    lastCommittedCropRef.current = cropBounds;
 
-      if (currentWidth === 0 || currentHeight === 0) {
-        return prevCrop;
-      }
-
-      // Calculate current aspect ratio (width/height in percent space)
-      // Note: aspect prop is width/height ratio
-      const currentAspect = currentWidth / currentHeight;
-
-      // If aspect is already close enough, don't adjust
-      if (Math.abs(currentAspect - aspect) < 0.01) {
-        return prevCrop;
-      }
-
-      // Adjust crop to match new aspect ratio, keeping center point
-      let newWidth = currentWidth;
-      let newHeight = currentHeight;
-
-      if (currentAspect > aspect) {
-        // Current crop is wider than target - reduce width
-        newWidth = currentHeight * aspect;
-      } else {
-        // Current crop is taller than target - reduce height
-        newHeight = currentWidth / aspect;
-      }
-
-      // Adjust position to keep the crop centered
-      const centerX = currentX + currentWidth / 2;
-      const centerY = currentY + currentHeight / 2;
-      let newX = centerX - newWidth / 2;
-      let newY = centerY - newHeight / 2;
-
-      // Clamp to image bounds (0-100%)
-      if (newX < 0) {
-        newX = 0;
-      } else if (newX + newWidth > 100) {
-        newX = 100 - newWidth;
-      }
-      if (newY < 0) {
-        newY = 0;
-      } else if (newY + newHeight > 100) {
-        newY = 100 - newHeight;
-      }
-
-      const adjustedCrop: PercentCrop = {
-        unit: "%",
-        x: newX,
-        y: newY,
-        width: newWidth,
-        height: newHeight,
-      };
-
-      // Update the committed crop ref and notify Streamlit
-      if (trackCrop) {
-        const cropBounds = percentCropToCropBounds(adjustedCrop);
-        lastCommittedCropRef.current = cropBounds;
-        setStateValue("crop", cropBounds);
-      }
-
-      return adjustedCrop;
-    });
-  }, [aspect, trackCrop, setStateValue]);
+    // Notify Streamlit of the adjusted crop
+    if (trackCrop) {
+      setStateValue("crop", cropBounds);
+    }
+  }, [initialCrop, aspect, trackCrop, setStateValue]);
 
   // Cleanup for debounce timer on unmount
   useEffect(() => {

--- a/src/streamlit_extras/image_crop/frontend/src/ImageCrop.tsx
+++ b/src/streamlit_extras/image_crop/frontend/src/ImageCrop.tsx
@@ -1,0 +1,399 @@
+import { FrontendRendererArgs } from "@streamlit/component-v2-lib";
+import {
+  CSSProperties,
+  FC,
+  ReactElement,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import ReactCrop, { type Crop, type PercentCrop, type PixelCrop } from "react-image-crop";
+// Import CSS as raw string to render inline
+import reactCropStyles from "react-image-crop/dist/ReactCrop.css?raw";
+
+// Custom overrides for Streamlit theming
+const CUSTOM_STYLES = `
+.ReactCrop__crop-selection {
+  border: 2px solid var(--st-primary-color, #ff4b4b) !important;
+}
+.ReactCrop__drag-handle {
+  width: 12px !important;
+  height: 12px !important;
+  background-color: var(--st-primary-color, #ff4b4b) !important;
+  border: 2px solid #fff !important;
+}
+/* Make edge handles easier to grab */
+.ReactCrop .ord-n,
+.ReactCrop .ord-s {
+  width: 24px !important;
+  height: 10px !important;
+  border-radius: 4px !important;
+}
+.ReactCrop .ord-e,
+.ReactCrop .ord-w {
+  width: 10px !important;
+  height: 24px !important;
+  border-radius: 4px !important;
+}
+`;
+
+// Combined styles to render inline
+const ALL_STYLES = reactCropStyles + "\n" + CUSTOM_STYLES;
+
+export type CropBounds = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+export type ImageCropStateShape = {
+  crop: CropBounds | null;
+};
+
+export type ImageCropDataShape = {
+  image_url: string;
+  aspect: number | null;
+  min_width: number;
+  min_height: number;
+  initial_crop: CropBounds | null;
+  circular: boolean;
+  rule_of_thirds: boolean;
+  height: "content" | number;
+  width: "content" | "stretch" | number;
+  track_crop: boolean;
+};
+
+export type ImageCropProps = Pick<
+  FrontendRendererArgs<ImageCropStateShape, ImageCropDataShape>,
+  "setStateValue"
+> & {
+  imageUrl: string;
+  aspect: number | null;
+  minWidth: number;
+  minHeight: number;
+  initialCrop: CropBounds | null;
+  circular: boolean;
+  ruleOfThirds: boolean;
+  height: "content" | number;
+  width: "content" | "stretch" | number;
+  trackCrop: boolean;
+};
+
+// Typed global Window interface for Streamlit
+declare global {
+  interface Window {
+    __streamlit?: {
+      DOWNLOAD_ASSETS_BASE_URL?: string;
+    };
+  }
+}
+
+/**
+ * Resolve media URLs to absolute URLs.
+ * Handles /media/ paths from Streamlit's media file storage.
+ */
+function resolveMediaUrl(url: string): string {
+  if (!url) return url;
+
+  // Already absolute URL or data URL
+  if (
+    url.startsWith("http://") ||
+    url.startsWith("https://") ||
+    url.startsWith("data:")
+  ) {
+    return url;
+  }
+
+  // Handle /media/ paths
+  if (url.startsWith("/media/") || url.startsWith("media/")) {
+    const normalizedUrl = url.startsWith("/") ? url : "/" + url;
+
+    // Try to get base URL from Streamlit config or window location
+    let baseUrl = "";
+    if (window.__streamlit?.DOWNLOAD_ASSETS_BASE_URL) {
+      baseUrl = window.__streamlit.DOWNLOAD_ASSETS_BASE_URL;
+    } else if (window.location) {
+      baseUrl = window.location.origin + window.location.pathname;
+    }
+
+    if (baseUrl) {
+      try {
+        const parsed = new URL(baseUrl);
+        let basePath = parsed.pathname;
+        if (!basePath.endsWith("/")) {
+          const lastSlash = basePath.lastIndexOf("/");
+          basePath = lastSlash > 0 ? basePath.substring(0, lastSlash) : "";
+        } else {
+          basePath = basePath.slice(0, -1);
+        }
+        return parsed.origin + (basePath + normalizedUrl).replace(/\/+/g, "/");
+      } catch {
+        return url;
+      }
+    }
+  }
+
+  return url;
+}
+
+/**
+ * Convert CropBounds to react-image-crop's PercentCrop format.
+ */
+function cropBoundsToPercentCrop(bounds: CropBounds): PercentCrop {
+  return {
+    unit: "%",
+    x: bounds.x,
+    y: bounds.y,
+    width: bounds.width,
+    height: bounds.height,
+  };
+}
+
+/**
+ * Convert react-image-crop's PercentCrop to CropBounds.
+ */
+function percentCropToCropBounds(crop: PercentCrop): CropBounds {
+  return {
+    x: crop.x,
+    y: crop.y,
+    width: crop.width,
+    height: crop.height,
+  };
+}
+
+/**
+ * Image cropping component using react-image-crop.
+ */
+const ImageCrop: FC<ImageCropProps> = ({
+  imageUrl,
+  aspect,
+  minWidth,
+  minHeight,
+  initialCrop,
+  circular,
+  ruleOfThirds,
+  height,
+  width,
+  trackCrop,
+  setStateValue,
+}): ReactElement => {
+  const [crop, setCrop] = useState<Crop | undefined>(() =>
+    initialCrop ? cropBoundsToPercentCrop(initialCrop) : undefined,
+  );
+  const [imageHeight, setImageHeight] = useState<number | null>(
+    typeof height === "number" ? height : null,
+  );
+  const containerRef = useRef<HTMLDivElement>(null);
+  const imgRef = useRef<HTMLImageElement>(null);
+
+  // Refs for debounced crop updates
+  const pendingCropRef = useRef<CropBounds | null>(null);
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastCommittedCropRef = useRef<CropBounds | null>(initialCrop);
+
+  // Debounce delay in milliseconds
+  const DEBOUNCE_DELAY = 150;
+
+  // Resolve media URL
+  const resolvedImageUrl = useMemo(
+    () => resolveMediaUrl(imageUrl),
+    [imageUrl],
+  );
+
+  // Sync crop when initialCrop changes (e.g., when props change on rerun)
+  useEffect(() => {
+    if (initialCrop) {
+      setCrop(cropBoundsToPercentCrop(initialCrop));
+      lastCommittedCropRef.current = initialCrop;
+    } else {
+      setCrop(undefined);
+      lastCommittedCropRef.current = null;
+    }
+  }, [initialCrop]);
+
+  // Cleanup for debounce timer on unmount
+  useEffect(() => {
+    return () => {
+      if (debounceTimerRef.current !== null) {
+        clearTimeout(debounceTimerRef.current);
+      }
+    };
+  }, []);
+
+  // Clear pending debounce timer when tracking is disabled
+  useEffect(() => {
+    if (!trackCrop && debounceTimerRef.current !== null) {
+      clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = null;
+    }
+  }, [trackCrop]);
+
+  // Calculate height based on image aspect ratio if height is "content"
+  useEffect(() => {
+    if (typeof height === "number") {
+      setImageHeight(height);
+      return;
+    }
+
+    let isMounted = true;
+    let aspectRatio: number | null = null;
+    const container = containerRef.current;
+
+    const updateImageHeight = () => {
+      if (!isMounted || !containerRef.current || aspectRatio === null) {
+        return;
+      }
+      const containerWidth = containerRef.current.clientWidth;
+      setImageHeight(Math.round(containerWidth * aspectRatio));
+    };
+
+    // Load image to get dimensions
+    const img = new Image();
+    img.onload = () => {
+      if (!isMounted || img.width === 0) {
+        return;
+      }
+      aspectRatio = img.height / img.width;
+      updateImageHeight();
+    };
+    img.src = resolvedImageUrl;
+
+    // Observe container resize to update height
+    let resizeObserver: ResizeObserver | null = null;
+    if (container) {
+      resizeObserver = new ResizeObserver(() => {
+        updateImageHeight();
+      });
+      resizeObserver.observe(container);
+    }
+
+    return () => {
+      isMounted = false;
+      img.onload = null;
+      if (resizeObserver) {
+        resizeObserver.disconnect();
+      }
+    };
+  }, [height, resolvedImageUrl]);
+
+  // Handle crop change with debouncing to prevent rapid reruns
+  const handleCropChange = useCallback(
+    (_pixelCrop: PixelCrop, percentCrop: PercentCrop) => {
+      setCrop(percentCrop);
+
+      // Only send state updates if tracking is enabled
+      if (!trackCrop) {
+        return;
+      }
+
+      const cropBounds = percentCropToCropBounds(percentCrop);
+      pendingCropRef.current = cropBounds;
+
+      // Debounce state updates to avoid excessive reruns
+      if (debounceTimerRef.current !== null) {
+        clearTimeout(debounceTimerRef.current);
+      }
+
+      debounceTimerRef.current = setTimeout(() => {
+        debounceTimerRef.current = null;
+
+        if (pendingCropRef.current !== null) {
+          const pending = pendingCropRef.current;
+          const last = lastCommittedCropRef.current;
+
+          // Only update if crop has changed
+          if (
+            !last ||
+            pending.x !== last.x ||
+            pending.y !== last.y ||
+            pending.width !== last.width ||
+            pending.height !== last.height
+          ) {
+            lastCommittedCropRef.current = pending;
+            setStateValue("crop", pending);
+          }
+        }
+      }, DEBOUNCE_DELAY);
+    },
+    [setStateValue, trackCrop],
+  );
+
+  // Handle crop complete (final update after drag ends)
+  const handleCropComplete = useCallback(
+    (_pixelCrop: PixelCrop, percentCrop: PercentCrop) => {
+      if (!trackCrop) {
+        return;
+      }
+
+      // Clear any pending debounce and commit immediately
+      if (debounceTimerRef.current !== null) {
+        clearTimeout(debounceTimerRef.current);
+        debounceTimerRef.current = null;
+      }
+
+      const cropBounds = percentCropToCropBounds(percentCrop);
+      lastCommittedCropRef.current = cropBounds;
+      setStateValue("crop", cropBounds);
+    },
+    [setStateValue, trackCrop],
+  );
+
+  // Container styles
+  const containerStyle = useMemo<CSSProperties>(() => {
+    const style: CSSProperties = {
+      position: "relative",
+      overflow: "hidden",
+    };
+
+    if (width === "stretch") {
+      style.width = "100%";
+    } else if (typeof width === "number") {
+      style.width = `${width}px`;
+    } else {
+      style.width = "fit-content";
+    }
+
+    if (imageHeight !== null) {
+      style.height = `${imageHeight}px`;
+    }
+
+    return style;
+  }, [width, imageHeight]);
+
+  return (
+    <div ref={containerRef} style={containerStyle}>
+      <style>{ALL_STYLES}</style>
+      <ReactCrop
+        crop={crop}
+        onChange={handleCropChange}
+        onComplete={handleCropComplete}
+        aspect={aspect ?? undefined}
+        minWidth={minWidth}
+        minHeight={minHeight}
+        circularCrop={circular}
+        ruleOfThirds={ruleOfThirds}
+        style={{
+          width: "100%",
+          height: imageHeight !== null ? `${imageHeight}px` : "auto",
+        }}
+      >
+        <img
+          ref={imgRef}
+          src={resolvedImageUrl}
+          alt="Crop source"
+          style={{
+            display: "block",
+            maxWidth: "100%",
+            height: imageHeight !== null ? `${imageHeight}px` : "auto",
+            objectFit: "contain",
+          }}
+        />
+      </ReactCrop>
+    </div>
+  );
+};
+
+export default ImageCrop;

--- a/src/streamlit_extras/image_crop/frontend/src/ImageCrop.tsx
+++ b/src/streamlit_extras/image_crop/frontend/src/ImageCrop.tsx
@@ -205,8 +205,14 @@ const ImageCrop: FC<ImageCropProps> = ({
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastCommittedCropRef = useRef<CropBounds | null>(initialCrop);
 
+  // Track previous initialCrop values to detect actual changes (not just reference changes)
+  const prevInitialCropRef = useRef<CropBounds | null>(initialCrop);
+
   // Track image aspect ratio for crop adjustments
   const [imageAspectRatio, setImageAspectRatio] = useState<number | null>(null);
+
+  // Track if initial crop adjustment has been applied (to avoid re-applying on re-renders)
+  const initialCropAppliedRef = useRef(false);
 
   // Debounce delay in milliseconds
   const DEBOUNCE_DELAY = 150;
@@ -216,6 +222,13 @@ const ImageCrop: FC<ImageCropProps> = ({
     () => resolveMediaUrl(imageUrl),
     [imageUrl],
   );
+
+  // Helper to compare crop bounds by value
+  const cropBoundsEqual = (a: CropBounds | null, b: CropBounds | null): boolean => {
+    if (a === b) return true;
+    if (!a || !b) return false;
+    return a.x === b.x && a.y === b.y && a.width === b.width && a.height === b.height;
+  };
 
   // Load image to get its aspect ratio
   useEffect(() => {
@@ -231,11 +244,28 @@ const ImageCrop: FC<ImageCropProps> = ({
     };
   }, [resolvedImageUrl]);
 
-  // Sync crop when initialCrop, aspect, or image dimensions change
+  // Sync crop when initialCrop values actually change or aspect/imageAspectRatio change
   useEffect(() => {
+    // Check if initialCrop values actually changed (not just reference)
+    const initialCropChanged = !cropBoundsEqual(initialCrop, prevInitialCropRef.current);
+    prevInitialCropRef.current = initialCrop;
+
+    // Skip if initialCrop hasn't changed, we've already applied the initial adjustment,
+    // and we have the image dimensions (so aspect adjustment was already done)
+    if (!initialCropChanged && initialCropAppliedRef.current && imageAspectRatio !== null) {
+      return;
+    }
+
     if (!initialCrop) {
       setCrop(undefined);
       lastCommittedCropRef.current = null;
+      initialCropAppliedRef.current = true;
+      return;
+    }
+
+    // If we don't have image dimensions yet and there's an aspect constraint,
+    // wait for the image to load before applying the crop
+    if (aspect && imageAspectRatio === null) {
       return;
     }
 
@@ -300,6 +330,7 @@ const ImageCrop: FC<ImageCropProps> = ({
     setCrop(cropToSet);
     const cropBounds = percentCropToCropBounds(cropToSet);
     lastCommittedCropRef.current = cropBounds;
+    initialCropAppliedRef.current = true;
 
     // Notify Streamlit of the adjusted crop
     if (trackCrop) {

--- a/src/streamlit_extras/image_crop/frontend/src/index.tsx
+++ b/src/streamlit_extras/image_crop/frontend/src/index.tsx
@@ -1,0 +1,83 @@
+import {
+  FrontendRenderer,
+  FrontendRendererArgs,
+} from "@streamlit/component-v2-lib";
+import { StrictMode } from "react";
+import { createRoot, Root } from "react-dom/client";
+
+import ImageCrop, { ImageCropDataShape, ImageCropStateShape } from "./ImageCrop";
+
+// Handle the possibility of multiple instances of the component to keep track
+// of the React roots for each component instance.
+const reactRoots: WeakMap<FrontendRendererArgs["parentElement"], Root> =
+  new WeakMap();
+
+const ImageCropRoot: FrontendRenderer<ImageCropStateShape, ImageCropDataShape> =
+  (args) => {
+    const { data, parentElement, setStateValue } = args;
+
+    // Get the react-root div from the parentElement that we defined in our
+    // `st.components.v2.component` call in Python.
+    const rootElement = parentElement.querySelector(".react-root");
+
+    if (!rootElement) {
+      throw new Error("Unexpected: React root element not found");
+    }
+
+    // Check to see if we already have a React root for this component instance.
+    let reactRoot = reactRoots.get(parentElement);
+    if (!reactRoot) {
+      // If we don't, create a new root for the React application using the React
+      // DOM API.
+      // @see https://react.dev/reference/react-dom/client/createRoot
+      reactRoot = createRoot(rootElement);
+      reactRoots.set(parentElement, reactRoot);
+    }
+
+    // Extract data passed from Streamlit on the Python side.
+    const {
+      image_url,
+      aspect,
+      min_width,
+      min_height,
+      initial_crop,
+      circular,
+      rule_of_thirds,
+      height,
+      width,
+      track_crop,
+    } = data;
+
+    // Render/re-render the React application into the root using the React DOM
+    // API.
+    reactRoot.render(
+      <StrictMode>
+        <ImageCrop
+          setStateValue={setStateValue}
+          imageUrl={image_url}
+          aspect={aspect}
+          minWidth={min_width}
+          minHeight={min_height}
+          initialCrop={initial_crop}
+          circular={circular}
+          ruleOfThirds={rule_of_thirds}
+          height={height}
+          width={width}
+          trackCrop={track_crop}
+        />
+      </StrictMode>,
+    );
+
+    // Return a function to cleanup the React application in the Streamlit
+    // component lifecycle.
+    return () => {
+      const reactRoot = reactRoots.get(parentElement);
+
+      if (reactRoot) {
+        reactRoot.unmount();
+        reactRoots.delete(parentElement);
+      }
+    };
+  };
+
+export default ImageCropRoot;

--- a/src/streamlit_extras/image_crop/frontend/src/vite-env.d.ts
+++ b/src/streamlit_extras/image_crop/frontend/src/vite-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="vite/client" />
+
+declare module "*.css?raw" {
+  const content: string;
+  export default content;
+}

--- a/src/streamlit_extras/image_crop/frontend/tsconfig.json
+++ b/src/streamlit_extras/image_crop/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/src/streamlit_extras/image_crop/frontend/vite.config.ts
+++ b/src/streamlit_extras/image_crop/frontend/vite.config.ts
@@ -1,0 +1,49 @@
+import react from "@vitejs/plugin-react";
+import process from "node:process";
+import { defineConfig, UserConfig } from "vite";
+
+/**
+ * Vite configuration for Streamlit Custom Component v2 development using React.
+ *
+ * @see https://vitejs.dev/config/ for complete Vite configuration options.
+ */
+export default defineConfig(() => {
+  const isProd = process.env.NODE_ENV === "production";
+  const isDev = !isProd;
+
+  return {
+    base: "./",
+    plugins: [react()],
+    define: {
+      // We are building in library mode, we need to define the NODE_ENV
+      // variable to prevent issues when executing the JS.
+      "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV),
+    },
+    build: {
+      minify: isDev ? false : "esbuild",
+      outDir: "build",
+      sourcemap: isDev,
+      cssCodeSplit: false,
+      lib: {
+        entry: "./src/index.tsx",
+        name: "ImageCrop",
+        formats: ["es"],
+        fileName: "index-[hash]",
+      },
+      rollupOptions: {
+        output: {
+          // Inline CSS into the JS bundle
+          assetFileNames: "[name]-[hash][extname]",
+        },
+      },
+      ...(!isDev && {
+        esbuild: {
+          drop: ["console", "debugger"],
+          minifyIdentifiers: true,
+          minifySyntax: true,
+          minifyWhitespace: true,
+        },
+      }),
+    },
+  } satisfies UserConfig;
+});

--- a/src/streamlit_extras/pyproject.toml
+++ b/src/streamlit_extras/pyproject.toml
@@ -9,6 +9,9 @@ version = "0.0.1"
 name = "image_compare_slider"
 asset_dir = "image_compare_slider/frontend/build"
 [[tool.streamlit.component.components]]
+name = "image_crop"
+asset_dir = "image_crop/frontend/build"
+[[tool.streamlit.component.components]]
 name = "json_editor"
 asset_dir = "json_editor/frontend/build"
 [[tool.streamlit.component.components]]


### PR DESCRIPTION
## Summary

<img width="639" height="436" alt="image" src="https://github.com/user-attachments/assets/2d691d4b-5c9d-44c9-8700-b3b545dad2b0" />


- Adds new `image_crop` extra based on react-image-crop for interactive image cropping
- Returns normalized crop bounds (0-1) for x, y, width, and height
- Supports aspect ratio constraints, circular masks, and rule-of-thirds guidelines
- Includes CCv2 React frontend with Streamlit theming

## Test plan