### PR TITLE
Fix resizable_columns CCv2 component registration

### DIFF
--- a/.github/workflows/pypi_action.yml
+++ b/.github/workflows/pypi_action.yml
@@ -20,6 +20,11 @@ jobs:
         with:
           python-version-file: ".python-version"
 
+      - name: "Set up Node.js"
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
       - name: "Build package"
         run: uv build
 

--- a/scripts/hatch_build.py
+++ b/scripts/hatch_build.py
@@ -25,7 +25,7 @@ class FrontendBuildHook(BuildHookInterface):
 
     PLUGIN_NAME = "frontend-build"
 
-    def initialize(self, _version: str, _build_data: dict[str, Any]) -> None:
+    def initialize(self, _version: str, build_data: dict[str, Any]) -> None:
         """Build all React CCv2 frontends before the wheel is packaged."""
         extras = self._find_react_extras()
 
@@ -38,6 +38,13 @@ class FrontendBuildHook(BuildHookInterface):
             self._build_frontend(extra_dir)
 
         self._update_shared_manifest(extras)
+
+        # Explicitly mark the generated build artifacts so hatchling includes
+        # them in the wheel even though they are listed in .gitignore.
+        for extra_dir in extras:
+            build_data["artifacts"].append(
+                f"{EXTRAS_DIR}/{extra_dir.name}/frontend/build/**"
+            )
 
     def _find_react_extras(self) -> list[Path]:
         """Find all React-based CCv2 extras."""

--- a/tests/test_extras.py
+++ b/tests/test_extras.py
@@ -1,9 +1,14 @@
 import pkgutil
 from importlib import import_module
+from pathlib import Path
 
 import pytest
+import toml
 
 import streamlit_extras
+
+EXTRAS_DIR = Path(__file__).parent.parent / "src" / "streamlit_extras"
+CCv2_MANIFEST = EXTRAS_DIR / "pyproject.toml"
 
 
 def get_extras() -> list[str]:
@@ -63,3 +68,49 @@ def test_extra_tests(extra: str):
     if hasattr(mod, "__tests__"):
         for test in mod.__tests__:
             test()
+
+
+def test_ccv2_manifest_contains_all_react_extras() -> None:
+    """Verify the CCv2 pyproject.toml manifest is in sync with React-based extras.
+
+    Every extra that ships a frontend/package.json must be declared in
+    src/streamlit_extras/pyproject.toml with an asset_dir entry.  If this
+    test fails it means a new React extra was added (or removed) without
+    updating the manifest - which would cause a StreamlitAPIException at
+    runtime for any user of that component.
+    """
+    # Extras that have a frontend/package.json (i.e. React-based CCv2 extras)
+    react_extras = sorted(
+        p.parent.parent.name
+        for p in EXTRAS_DIR.glob("*/frontend/package.json")
+    )
+
+    assert CCv2_MANIFEST.exists(), (
+        f"CCv2 manifest not found at {CCv2_MANIFEST}. "
+        "Run `uv build` to regenerate it."
+    )
+
+    manifest_data = toml.loads(CCv2_MANIFEST.read_text())
+    declared_components: list[dict[str, str]] = (
+        manifest_data.get("tool", {})
+        .get("streamlit", {})
+        .get("component", {})
+        .get("components", [])
+    )
+    declared_names = {c["name"] for c in declared_components if "name" in c}
+
+    missing = sorted(set(react_extras) - declared_names)
+    assert not missing, (
+        f"The following React extras have a frontend/package.json but are NOT "
+        f"declared in {CCv2_MANIFEST.relative_to(EXTRAS_DIR.parent.parent)}:\n"
+        + "\n".join(f"  - {name}" for name in missing)
+        + "\nUpdate the manifest by running `uv build` and committing the result."
+    )
+
+    extra_entries = sorted(declared_names - set(react_extras))
+    assert not extra_entries, (
+        "The following names are declared in the CCv2 manifest but have no "
+        "corresponding frontend/package.json:\n"
+        + "\n".join(f"  - {name}" for name in extra_entries)
+        + "\nRemove stale entries from the manifest."
+    )


### PR DESCRIPTION
## Problem

Users see:
```
streamlit.errors.StreamlitAPIException: Component 'streamlit-extras.resizable_columns'
must be declared in pyproject.toml with asset_dir to use file-backed js.
```

Streamlit's CCv2 manifest scanner calls `resolve_asset_root()` for every component declared in `src/streamlit_extras/pyproject.toml`. If a component's `asset_dir` directory is absent, that call raises `StreamlitComponentRegistryError`, which causes the **entire** manifest registration to be silently swallowed. Any component that wasn't processed before the failure (here: `resizable_columns` and later) ends up with no registered asset root, producing the misleading "must be declared in pyproject.toml" error.

## Root causes

1. **Wheel may miss built JS files.** The existing hatchling `exclude` negation patterns (`!.../frontend/build/**`) are a best-effort hint; they do not override the `.gitignore`-based VCS exclusion that hatchling applies first. Using `build_data["artifacts"]` (the proper hook API) guarantees the generated files are always packaged.

2. **CI does not pin a Node.js version.** The publish workflow relied on whatever Node.js happened to be pre-installed on `ubuntu-latest`. A runner image update could silently break the frontend builds, producing a wheel without built assets.

3. **No test guards the manifest.** There was nothing preventing a future React extra from being committed without a matching entry in `src/streamlit_extras/pyproject.toml`, which would reproduce this bug for that component.

## Changes

- **`scripts/hatch_build.py`** – After building each frontend, add the generated `frontend/build/**` paths to `build_data["artifacts"]` so hatchling always includes them in the wheel regardless of `.gitignore`.
- **`.github/workflows/pypi_action.yml`** – Add an explicit `actions/setup-node@v4` step (Node.js 20 LTS) before `uv build`.
- **`tests/test_extras.py`** – Add `test_ccv2_manifest_contains_all_react_extras` which asserts every extra with a `frontend/package.json` is declared in the CCv2 manifest, and vice-versa.

## Test plan

- [x] `uv run pytest tests/test_extras.py::test_ccv2_manifest_contains_all_react_extras` passes
- [x] Full test suite passes (`109 passed`)
- [x] `uv run ruff check scripts/hatch_build.py tests/test_extras.py` passes

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)