### PR TITLE
Add directory_tree extra: collapsible file tree with Material icons

### DIFF
--- a/src/streamlit_extras/AGENTS.md
+++ b/src/streamlit_extras/AGENTS.md
@@ -49,6 +49,7 @@ Use this guide to select the appropriate implementation approach:
 | `concurrency_limiter` | Limit function execution concurrency | pure python |
 | `cookie_manager` | Read/write browser cookies from Python | components v2: inline |
 | `diagrams` | Render architecture diagrams with SVG output | components v2: inline |
+| `directory_tree` | Collapsible directory tree with Material icons and optional click-to-select | components v2: react |
 | `customize_running` | Customize the running widget appearance | st.html |
 | `dataframe_explorer` | Interactive dataframe filtering UI | pure python |
 | `echo_expander` | Show executed code in an expander | pure python |

--- a/src/streamlit_extras/directory_tree/__init__.py
+++ b/src/streamlit_extras/directory_tree/__init__.py
@@ -1,0 +1,403 @@
+"""Directory tree visualization for Streamlit.
+
+A collapsible directory tree component with Material icons, optional border,
+and optional click-to-select functionality. Toggling directories is purely
+client-side (no reruns). Selection can optionally trigger a rerun.
+"""
+
+from collections.abc import Callable
+from datetime import date
+from functools import cache
+from typing import Any, Literal
+
+import streamlit as st
+import streamlit.components.v2
+import streamlit.errors
+
+from streamlit_extras import extra
+
+
+def _on_select_change() -> None:
+    """Callback function for when a node is selected."""
+
+
+@cache
+def _get_component() -> Any:
+    """Lazily initialize the CCv2 component.
+
+    Returns:
+        The component callable.
+    """
+    return streamlit.components.v2.component(
+        "streamlit-extras.directory_tree",
+        js="index-*.js",
+        html='<div class="react-root"></div>',
+    )
+
+
+@extra
+def directory_tree(
+    tree: dict[str, Any],
+    *,
+    expanded: bool | int = False,
+    border: bool = False,
+    color: str | None = "primary",
+    on_select: Literal["rerun", "ignore"] = "ignore",
+    height: int | None = None,
+    key: str | None = None,
+) -> str | None:
+    """Display a collapsible directory tree.
+
+    Renders a nested directory structure with Material icons and expand/collapse
+    toggles. Toggling directories is purely client-side (no reruns). Optionally,
+    clicking a node can return its path to Python.
+
+    Args:
+        tree: Nested dict representing the file tree. Keys are file/directory
+            names. Values of None indicate files; dict values indicate
+            directories containing more entries.
+        expanded: Controls initial expansion. ``True`` expands all nodes,
+            ``False`` collapses all. An integer expands nodes up to that
+            depth (0 = all collapsed, 1 = top-level expanded, 2 = two
+            levels deep, etc.).
+        border: Whether to show a border around the tree container.
+        color: Color for directory folder icons. Defaults to ``"primary"``
+            which uses the Streamlit primary color. Pass any CSS color
+            string (e.g. ``"#ff6600"``, ``"orange"``), or ``None`` to
+            use the same text color as files (no special coloring).
+        on_select: Selection mode. "ignore" means clicks don't trigger reruns
+            (purely visual). "rerun" means clicking a node sends the path
+            back to Python and triggers a rerun.
+        height: Optional max height in pixels. If set, the tree scrolls
+            when content exceeds this height.
+        key: Unique key for this widget instance.
+
+    Returns:
+        The selected node path (e.g. "src/utils/helpers.py") when
+        on_select="rerun" and a node has been clicked, otherwise None.
+
+    Raises:
+        StreamlitAPIException: If tree is not a dict.
+
+    Example:
+
+        ```python
+        directory_tree(
+            {
+                "src": {"main.py": None, "utils": {"helpers.py": None}},
+                "README.md": None,
+            }
+        )
+        ```
+    """
+    if not isinstance(tree, dict):
+        raise streamlit.errors.StreamlitAPIException(f"tree must be a dict, got {type(tree).__name__}")
+
+    # Normalize expanded to a depth integer for the frontend:
+    # True -> very large number (all expanded), False -> 0, int -> as-is
+    if expanded is True:
+        expand_depth = 999
+    elif expanded is False:
+        expand_depth = 0
+    else:
+        expand_depth = int(expanded)
+
+    component = _get_component()
+
+    data = {
+        "tree": tree,
+        "expand_depth": expand_depth,
+        "border": border,
+        "color": color,
+        "selectable": on_select == "rerun",
+        "height": height,
+    }
+
+    if on_select == "rerun":
+        result = component(
+            key=key,
+            data=data,
+            default={"selected": ""},
+            on_selected_change=_on_select_change,
+        )
+        selected: str = result.get("selected", "")
+        return selected or None
+
+    component(key=key, data=data)
+    return None
+
+
+def example_basic() -> None:
+    """Basic directory tree display."""
+    st.write("### Basic Tree (collapsed by default)")
+    directory_tree(
+        {
+            "src": {
+                "app.py": None,
+                "components": {
+                    "header.tsx": None,
+                    "sidebar.tsx": None,
+                },
+                "utils": {
+                    "helpers.py": None,
+                    "constants.py": None,
+                },
+            },
+            "tests": {
+                "test_app.py": None,
+            },
+            "README.md": None,
+            "pyproject.toml": None,
+        },
+        key="basic_tree",
+    )
+
+    st.write("### Fully expanded")
+    directory_tree(
+        {
+            "src": {
+                "app.py": None,
+                "components": {
+                    "header.tsx": None,
+                    "sidebar.tsx": None,
+                },
+                "utils": {
+                    "helpers.py": None,
+                    "constants.py": None,
+                },
+            },
+            "tests": {
+                "test_app.py": None,
+            },
+            "README.md": None,
+            "pyproject.toml": None,
+        },
+        expanded=True,
+        key="expanded_tree",
+    )
+
+    st.write("### Expand one level deep (expanded=1)")
+    directory_tree(
+        {
+            "my_app": {
+                "src": {
+                    "main.py": None,
+                    "models": {
+                        "user.py": None,
+                        "post.py": None,
+                    },
+                    "routes": {
+                        "auth.py": None,
+                        "api.py": None,
+                    },
+                },
+                "tests": {
+                    "test_main.py": None,
+                    "test_models.py": None,
+                },
+                "pyproject.toml": None,
+            },
+        },
+        expanded=1,
+        key="depth1_tree",
+    )
+
+
+def example_colors() -> None:
+    """Folder icon color options."""
+    st.write("### Default (primary color)")
+    directory_tree(
+        {
+            "project": {
+                "src": {"index.ts": None, "utils": {"format.ts": None}},
+                "package.json": None,
+            },
+        },
+        expanded=True,
+        border=True,
+        key="color_primary",
+    )
+
+    st.write("### No color (color=None)")
+    directory_tree(
+        {
+            "project": {
+                "src": {"index.ts": None, "utils": {"format.ts": None}},
+                "package.json": None,
+            },
+        },
+        expanded=True,
+        border=True,
+        color=None,
+        key="color_none",
+    )
+
+    st.write("### Custom colors")
+    col1, col2, col3 = st.columns(3)
+    with col1:
+        directory_tree(
+            {"docs": {"guide.md": None, "api.md": None}},
+            expanded=True,
+            color="#2196F3",
+            key="color_blue",
+        )
+    with col2:
+        directory_tree(
+            {"src": {"main.py": None, "utils.py": None}},
+            expanded=True,
+            color="#4CAF50",
+            key="color_green",
+        )
+    with col3:
+        directory_tree(
+            {"assets": {"logo.svg": None, "style.css": None}},
+            expanded=True,
+            color="#FF9800",
+            key="color_orange",
+        )
+
+
+def example_height() -> None:
+    """Fixed height with scrollable overflow."""
+    st.write("### Fixed height (height=150)")
+    directory_tree(
+        {
+            "large_project": {
+                "src": {
+                    "components": {
+                        "Button.tsx": None,
+                        "Modal.tsx": None,
+                        "Sidebar.tsx": None,
+                        "Header.tsx": None,
+                        "Footer.tsx": None,
+                        "Card.tsx": None,
+                        "Avatar.tsx": None,
+                    },
+                    "hooks": {
+                        "useAuth.ts": None,
+                        "useTheme.ts": None,
+                        "useData.ts": None,
+                    },
+                    "pages": {
+                        "Home.tsx": None,
+                        "Dashboard.tsx": None,
+                        "Settings.tsx": None,
+                        "Profile.tsx": None,
+                    },
+                    "App.tsx": None,
+                    "index.tsx": None,
+                },
+                "public": {
+                    "index.html": None,
+                    "favicon.ico": None,
+                },
+                "package.json": None,
+                "tsconfig.json": None,
+                "README.md": None,
+            },
+        },
+        expanded=True,
+        border=True,
+        height=150,
+        key="height_tree",
+    )
+
+    st.write("### Long filenames get ellipsis")
+    directory_tree(
+        {
+            "src": {
+                "this_is_a_very_long_filename_that_should_be_truncated_with_ellipsis.tsx": None,
+                "another_extremely_long_component_name_for_testing_overflow.test.tsx": None,
+                "components": {
+                    "SuperLongComponentNameThatExceedsTheContainerWidth.tsx": None,
+                    "short.ts": None,
+                },
+            },
+        },
+        expanded=True,
+        border=True,
+        key="long_names_tree",
+    )
+
+    st.write("### Taller height (height=300)")
+    directory_tree(
+        {
+            "monorepo": {
+                "apps": {
+                    "web": {
+                        "src": {"App.tsx": None, "main.tsx": None},
+                        "package.json": None,
+                    },
+                    "mobile": {
+                        "src": {"App.tsx": None, "main.tsx": None},
+                        "package.json": None,
+                    },
+                    "api": {
+                        "src": {"server.ts": None, "routes.ts": None},
+                        "package.json": None,
+                    },
+                },
+                "packages": {
+                    "ui": {"src": {"Button.tsx": None, "Input.tsx": None}},
+                    "utils": {"src": {"format.ts": None, "validate.ts": None}},
+                    "config": {"src": {"theme.ts": None, "env.ts": None}},
+                },
+                "turbo.json": None,
+                "package.json": None,
+            },
+        },
+        expanded=2,
+        border=True,
+        height=300,
+        key="height_tree_tall",
+    )
+
+
+def example_interactive() -> None:
+    """Interactive tree with click-to-select."""
+    st.write("### Click to select a file")
+    selected = directory_tree(
+        {
+            "frontend": {
+                "src": {
+                    "App.tsx": None,
+                    "index.tsx": None,
+                    "components": {
+                        "Button.tsx": None,
+                        "Modal.tsx": None,
+                        "Sidebar.tsx": None,
+                        "Header.tsx": None,
+                    },
+                },
+                "package.json": None,
+                "tsconfig.json": None,
+            },
+            "backend": {
+                "main.py": None,
+                "routes": {
+                    "auth.py": None,
+                    "api.py": None,
+                    "users.py": None,
+                },
+                "models": {
+                    "user.py": None,
+                    "session.py": None,
+                },
+            },
+        },
+        on_select="rerun",
+        border=True,
+        expanded=2,
+        height=200,
+        key="interactive_tree",
+    )
+    if selected:
+        st.success(f"Selected: `{selected}`")
+
+
+__title__ = "Directory Tree"
+__desc__ = "Collapsible directory tree with Material icons and optional click-to-select."
+__icon__ = "🌲"
+__examples__ = [example_basic, example_colors, example_height, example_interactive]
+__author__ = "streamlit-extras"
+__created_at__ = date(2026, 5, 15)

--- a/src/streamlit_extras/directory_tree/frontend/package.json
+++ b/src/streamlit_extras/directory_tree/frontend/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "directory-tree",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "npm run clean && npm run typecheck && npm run build:frontend:production",
+    "build:frontend:production": "cross-env NODE_ENV=production vite build",
+    "clean": "rimraf build",
+    "dev": "cross-env NODE_ENV=development vite build --watch",
+    "format": "prettier --write src/**/*.{ts,tsx} vite.config.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not ie <= 11",
+    "not op_mini all"
+  ],
+  "prettier": {},
+  "dependencies": {
+    "@streamlit/component-v2-lib": "^0.2.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "@types/react": "^18.3.20",
+    "@types/react-dom": "^18.3.6",
+    "@vitejs/plugin-react": "^5.1.0",
+    "cross-env": "^10.1.0",
+    "prettier": "^3.6.2",
+    "rimraf": "^6.1.0",
+    "typescript": "^5.8.3",
+    "vite": "^7.1.12"
+  }
+}

--- a/src/streamlit_extras/directory_tree/frontend/src/DirectoryTree.tsx
+++ b/src/streamlit_extras/directory_tree/frontend/src/DirectoryTree.tsx
@@ -1,0 +1,101 @@
+import { FrontendRendererArgs } from "@streamlit/component-v2-lib";
+import { FC, useMemo } from "react";
+import TreeNode from "./TreeNode";
+
+export interface TreeData {
+  [key: string]: TreeData | null;
+}
+
+export type DirectoryTreeStateShape = {
+  selected: string;
+};
+
+export type DirectoryTreeDataShape = {
+  tree: TreeData;
+  expand_depth: number;
+  border: boolean;
+  color: string | null;
+  selectable: boolean;
+  height: number | null;
+};
+
+export type DirectoryTreeProps = Pick<
+  FrontendRendererArgs<DirectoryTreeStateShape, DirectoryTreeDataShape>,
+  "setStateValue"
+> & {
+  tree: TreeData;
+  expandDepth: number;
+  border: boolean;
+  color: string | null;
+  selectable: boolean;
+  height: number | null;
+};
+
+const containerStyle = (
+  showBorder: boolean,
+  height: number | null,
+): React.CSSProperties => ({
+  fontFamily: "var(--st-font, sans-serif)",
+  fontSize: "var(--st-base-font-size, 14px)",
+  color: "var(--st-text-color, #262730)",
+  padding: "8px 4px",
+  overflow: "hidden",
+  ...(showBorder && {
+    border: "1px solid var(--st-border-color, #e6e6e9)",
+    borderRadius: "var(--st-base-radius, 0.5rem)",
+    padding: "12px",
+  }),
+  ...(height && {
+    maxHeight: `${height}px`,
+    overflowY: "auto" as const,
+  }),
+});
+
+const DirectoryTree: FC<DirectoryTreeProps> = ({
+  tree,
+  expandDepth,
+  border,
+  color,
+  selectable,
+  height,
+  setStateValue,
+}) => {
+  const style = useMemo(() => containerStyle(border, height), [border, height]);
+
+  const handleSelect = (path: string) => {
+    if (selectable) {
+      setStateValue("selected", path);
+    }
+  };
+
+  // Sort entries: directories first, then files, alphabetical within each group
+  const sortedEntries = useMemo(() => {
+    return Object.entries(tree).sort(([aName, aVal], [bName, bVal]) => {
+      const aIsDir = aVal !== null;
+      const bIsDir = bVal !== null;
+      if (aIsDir && !bIsDir) return -1;
+      if (!aIsDir && bIsDir) return 1;
+      return aName.localeCompare(bName);
+    });
+  }, [tree]);
+
+  return (
+    <div style={style}>
+      {sortedEntries.map(([name, value]) => (
+        <TreeNode
+          key={name}
+          name={name}
+          value={value}
+          path={name}
+          depth={0}
+          expandDepth={expandDepth}
+          color={color}
+          selectable={selectable}
+          onSelect={handleSelect}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default DirectoryTree;

--- a/src/streamlit_extras/directory_tree/frontend/src/TreeNode.tsx
+++ b/src/streamlit_extras/directory_tree/frontend/src/TreeNode.tsx
@@ -1,0 +1,329 @@
+import { FC, useCallback, useEffect, useMemo, useState } from "react";
+import { TreeData } from "./DirectoryTree";
+
+type TreeNodeProps = {
+  name: string;
+  value: TreeData | null;
+  path: string;
+  depth: number;
+  expandDepth: number;
+  color: string | null;
+  selectable: boolean;
+  onSelect: (path: string) => void;
+};
+
+// Track font loading state globally (shared across all TreeNode instances)
+let fontLoaded = false;
+const fontLoadedListeners: Array<() => void> = [];
+
+function notifyFontLoaded() {
+  fontLoaded = true;
+  for (const listener of fontLoadedListeners) {
+    listener();
+  }
+  fontLoadedListeners.length = 0;
+}
+
+// Inject Material Symbols font and track when it's ready
+const FONT_ID = "material-symbols-directory-tree";
+if (typeof document !== "undefined" && !document.getElementById(FONT_ID)) {
+  const link = document.createElement("link");
+  link.id = FONT_ID;
+  link.rel = "stylesheet";
+  link.href =
+    "https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=swap";
+  document.head.appendChild(link);
+
+  // Wait for the font to actually load
+  document.fonts.ready.then(() => {
+    document.fonts
+      .load("18px 'Material Symbols Outlined'")
+      .then(() => notifyFontLoaded())
+      .catch(() => notifyFontLoaded());
+  });
+} else {
+  // Font link already exists, check if it's loaded
+  document.fonts
+    .check("18px 'Material Symbols Outlined'")
+    ? (fontLoaded = true)
+    : document.fonts.ready.then(() => notifyFontLoaded());
+}
+
+function useFontLoaded(): boolean {
+  const [loaded, setLoaded] = useState(fontLoaded);
+  useEffect(() => {
+    if (fontLoaded) {
+      setLoaded(true);
+      return;
+    }
+    const listener = () => setLoaded(true);
+    fontLoadedListeners.push(listener);
+    return () => {
+      const idx = fontLoadedListeners.indexOf(listener);
+      if (idx >= 0) fontLoadedListeners.splice(idx, 1);
+    };
+  }, []);
+  return loaded;
+}
+
+/**
+ * Get a Material Symbols icon name based on file extension.
+ */
+function getFileIcon(filename: string): string {
+  const ext = filename.split(".").pop()?.toLowerCase() ?? "";
+  switch (ext) {
+    case "py":
+    case "ts":
+    case "tsx":
+    case "js":
+    case "jsx":
+    case "rs":
+    case "go":
+    case "java":
+    case "c":
+    case "cpp":
+    case "h":
+    case "rb":
+    case "php":
+    case "swift":
+    case "kt":
+      return "code";
+    case "md":
+    case "mdx":
+    case "txt":
+    case "rst":
+      return "description";
+    case "json":
+    case "yaml":
+    case "yml":
+    case "toml":
+    case "xml":
+    case "ini":
+    case "cfg":
+    case "conf":
+      return "settings";
+    case "png":
+    case "jpg":
+    case "jpeg":
+    case "gif":
+    case "svg":
+    case "webp":
+    case "ico":
+      return "image";
+    case "css":
+    case "scss":
+    case "sass":
+    case "less":
+      return "palette";
+    case "html":
+    case "htm":
+      return "web";
+    case "sh":
+    case "bash":
+    case "zsh":
+    case "fish":
+      return "terminal";
+    case "lock":
+      return "lock";
+    case "env":
+      return "vpn_key";
+    case "gitignore":
+    case "dockerignore":
+      return "visibility_off";
+    default:
+      return "draft";
+  }
+}
+
+const iconStyle: React.CSSProperties = {
+  fontFamily: "'Material Symbols Outlined'",
+  fontWeight: "normal",
+  fontStyle: "normal",
+  fontSize: "18px",
+  lineHeight: 1,
+  letterSpacing: "normal",
+  textTransform: "none",
+  display: "inline-block",
+  whiteSpace: "nowrap",
+  wordWrap: "normal",
+  direction: "ltr",
+  fontFeatureSettings: "'liga'",
+  WebkitFontSmoothing: "antialiased",
+  flexShrink: 0,
+  userSelect: "none",
+};
+
+const rowStyle = (
+  depth: number,
+  selectable: boolean,
+  isHovered: boolean,
+): React.CSSProperties => ({
+  display: "flex",
+  alignItems: "center",
+  gap: "4px",
+  padding: "3px 6px",
+  paddingLeft: `${depth * 20 + 6}px`,
+  borderRadius: "4px",
+  cursor: selectable ? "pointer" : "default",
+  backgroundColor: isHovered
+    ? "var(--st-secondary-background-color, #f0f2f6)"
+    : "transparent",
+  transition: "background-color 0.1s ease",
+  userSelect: "none",
+  minWidth: 0,
+  overflow: "hidden",
+});
+
+const nameStyle: React.CSSProperties = {
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+  lineHeight: "24px",
+  minWidth: 0,
+};
+
+const TreeNode: FC<TreeNodeProps> = ({
+  name,
+  value,
+  path,
+  depth,
+  expandDepth,
+  color,
+  selectable,
+  onSelect,
+}) => {
+  const isDirectory = value !== null;
+  const [isExpanded, setIsExpanded] = useState(depth < expandDepth);
+  const [isHovered, setIsHovered] = useState(false);
+  const isFontReady = useFontLoaded();
+
+  const handleClick = useCallback(() => {
+    if (isDirectory) {
+      setIsExpanded((prev) => !prev);
+    }
+    if (selectable) {
+      onSelect(path);
+    }
+  }, [isDirectory, selectable, onSelect, path]);
+
+  const icon = useMemo(() => {
+    if (isDirectory) {
+      return isExpanded ? "folder_open" : "folder";
+    }
+    return getFileIcon(name);
+  }, [isDirectory, isExpanded, name]);
+
+  const iconColor = useMemo((): string => {
+    if (isDirectory) {
+      if (color === null) {
+        return "var(--st-text-color, #262730)";
+      }
+      if (color === "primary") {
+        return "var(--st-primary-color, #ff4b4b)";
+      }
+      return color;
+    }
+    return "var(--st-text-color, #262730)";
+  }, [isDirectory, color]);
+
+  // Sort children: directories first, then files
+  const sortedChildren = useMemo(() => {
+    if (!isDirectory || value === null) return [];
+    return Object.entries(value).sort(([aName, aVal], [bName, bVal]) => {
+      const aIsDir = aVal !== null;
+      const bIsDir = bVal !== null;
+      if (aIsDir && !bIsDir) return -1;
+      if (!aIsDir && bIsDir) return 1;
+      return aName.localeCompare(bName);
+    });
+  }, [isDirectory, value]);
+
+  return (
+    <div>
+      <div
+        style={rowStyle(depth, selectable || isDirectory, isHovered)}
+        onClick={handleClick}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+        role={selectable ? "button" : undefined}
+        tabIndex={selectable || isDirectory ? 0 : undefined}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            handleClick();
+          }
+        }}
+      >
+        {/* Chevron for directories — always use SVG so there's no FOUT */}
+        {isDirectory ? (
+          <span
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+              width: "16px",
+              height: "16px",
+              flexShrink: 0,
+              transition: "transform 0.15s ease",
+              transform: isExpanded ? "rotate(90deg)" : "rotate(0deg)",
+              opacity: 0.6,
+            }}
+          >
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 16 16"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M6 4L10 8L6 12"
+                stroke="var(--st-text-color, #262730)"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </span>
+        ) : (
+          <span style={{ width: "16px", flexShrink: 0 }} />
+        )}
+
+        {/* File/folder icon — hidden until font loads to avoid FOUT */}
+        <span
+          style={{
+            ...iconStyle,
+            color: iconColor,
+            visibility: isFontReady ? "visible" : "hidden",
+          }}
+        >
+          {icon}
+        </span>
+
+        {/* Name */}
+        <span style={nameStyle}>{name}</span>
+      </div>
+
+      {/* Children (only render when expanded) */}
+      {isDirectory && isExpanded && (
+        <div>
+          {sortedChildren.map(([childName, childValue]) => (
+            <TreeNode
+              key={childName}
+              name={childName}
+              value={childValue}
+              path={`${path}/${childName}`}
+              depth={depth + 1}
+              expandDepth={expandDepth}
+              color={color}
+              selectable={selectable}
+              onSelect={onSelect}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TreeNode;

--- a/src/streamlit_extras/directory_tree/frontend/src/index.tsx
+++ b/src/streamlit_extras/directory_tree/frontend/src/index.tsx
@@ -1,0 +1,59 @@
+import {
+  FrontendRenderer,
+  FrontendRendererArgs,
+} from "@streamlit/component-v2-lib";
+import { StrictMode } from "react";
+import { createRoot, Root } from "react-dom/client";
+
+import DirectoryTree, {
+  DirectoryTreeDataShape,
+  DirectoryTreeStateShape,
+} from "./DirectoryTree";
+
+const reactRoots: WeakMap<FrontendRendererArgs["parentElement"], Root> =
+  new WeakMap();
+
+const DirectoryTreeRoot: FrontendRenderer<
+  DirectoryTreeStateShape,
+  DirectoryTreeDataShape
+> = (args) => {
+  const { data, parentElement, setStateValue } = args;
+
+  const rootElement = parentElement.querySelector(".react-root");
+
+  if (!rootElement) {
+    throw new Error("Unexpected: React root element not found");
+  }
+
+  let reactRoot = reactRoots.get(parentElement);
+  if (!reactRoot) {
+    reactRoot = createRoot(rootElement);
+    reactRoots.set(parentElement, reactRoot);
+  }
+
+  const { tree, expand_depth, border, color, selectable, height } = data;
+
+  reactRoot.render(
+    <StrictMode>
+      <DirectoryTree
+        tree={tree}
+        expandDepth={expand_depth}
+        border={border}
+        color={color}
+        selectable={selectable}
+        height={height}
+        setStateValue={setStateValue}
+      />
+    </StrictMode>,
+  );
+
+  return () => {
+    const reactRoot = reactRoots.get(parentElement);
+    if (reactRoot) {
+      reactRoot.unmount();
+      reactRoots.delete(parentElement);
+    }
+  };
+};
+
+export default DirectoryTreeRoot;

--- a/src/streamlit_extras/directory_tree/frontend/tsconfig.json
+++ b/src/streamlit_extras/directory_tree/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/src/streamlit_extras/directory_tree/frontend/vite.config.ts
+++ b/src/streamlit_extras/directory_tree/frontend/vite.config.ts
@@ -1,0 +1,40 @@
+import react from "@vitejs/plugin-react";
+import process from "node:process";
+import { defineConfig, UserConfig } from "vite";
+
+/**
+ * Vite configuration for Streamlit Custom Component v2 development using React.
+ *
+ * @see https://vitejs.dev/config/ for complete Vite configuration options.
+ */
+export default defineConfig(() => {
+  const isProd = process.env.NODE_ENV === "production";
+  const isDev = !isProd;
+
+  return {
+    base: "./",
+    plugins: [react()],
+    define: {
+      "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV),
+    },
+    build: {
+      minify: isDev ? false : "esbuild",
+      outDir: "build",
+      sourcemap: isDev,
+      lib: {
+        entry: "./src/index.tsx",
+        name: "DirectoryTree",
+        formats: ["es"],
+        fileName: "index-[hash]",
+      },
+      ...(!isDev && {
+        esbuild: {
+          drop: ["console", "debugger"],
+          minifyIdentifiers: true,
+          minifySyntax: true,
+          minifyWhitespace: true,
+        },
+      }),
+    },
+  } satisfies UserConfig;
+});

--- a/src/streamlit_extras/pyproject.toml
+++ b/src/streamlit_extras/pyproject.toml
@@ -9,6 +9,9 @@ version = "0.0.1"
 name = "chartjs_chart"
 asset_dir = "chartjs_chart/frontend/build"
 [[tool.streamlit.component.components]]
+name = "directory_tree"
+asset_dir = "directory_tree/frontend/build"
+[[tool.streamlit.component.components]]
 name = "image_compare_slider"
 asset_dir = "image_compare_slider/frontend/build"
 [[tool.streamlit.component.components]]


### PR DESCRIPTION
## Summary

- Adds a new `directory_tree` React-based CCv2 extra for visualizing nested directory structures
- Features collapsible directories (client-side toggle, no reruns), Material Symbols icons with file-type detection, optional border, and optional click-to-select that returns the path to Python
- Uses `--st-*` CSS variables for full Streamlit theme integration (light/dark)

## API

```python
from streamlit_extras.directory_tree import directory_tree

# Static display (no reruns)
directory_tree({"src": {"main.py": None, "utils": {"helpers.py": None}}})

# Interactive (returns selected path on click)
selected = directory_tree(tree, on_select="rerun", show_border=True, key="picker")
```

## Test plan

- [x] `npm run build` produces `build/index-*.js`
- [x] `uv run ruff check` passes
- [x] `uv run mypy` passes
- [x] `uv run pytest` — all 114 tests pass (includes metadata validation)
- [ ] Manual test with `uv run streamlit run gallery/streamlit_app.py`

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)