### PR TITLE
Fix ty linting: explicitly import streamlit.errors submodule

### DIFF
--- a/src/streamlit_extras/resizable_columns/__init__.py
+++ b/src/streamlit_extras/resizable_columns/__init__.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import streamlit as st
 import streamlit.components.v2
+import streamlit.errors
 from streamlit.delta_generator import DeltaGenerator
 
 from streamlit_extras import extra


### PR DESCRIPTION
## Summary

Fixes a `ty` type checker warning in `resizable_columns/__init__.py`:

\`\`\`
warning[possibly-missing-submodule]: Submodule `errors` might not have been imported
  --> src/streamlit_extras/resizable_columns/__init__.py:76:15
help: Consider explicitly importing `streamlit.errors`
\`\`\`

## Change

Added `import streamlit.errors` alongside the existing `import streamlit as st` to satisfy the type checker when accessing `st.errors.StreamlitAPIException`.

## Quality Checks

- `uv run ruff check` — ✅ All checks passed
- `uv run ruff format --check` — ✅ 59 files already formatted
- `uv run mypy` — ✅ No issues found in 55 source files
- `uv run ty check` — ✅ All checks passed